### PR TITLE
Fixed 404 handling in app generator.

### DIFF
--- a/tasks/praxis_app_generator.thor
+++ b/tasks/praxis_app_generator.thor
@@ -198,9 +198,6 @@ RUBY
 #     media_type media_type
 #   end
 Praxis::ApiDefinition.define do
-  response_template :not_found do
-    status 404
-  end
   trait :versionable do
     headers do
       header :X_Api_Version, String, values: ['1.0'], required: true


### PR DESCRIPTION
Return 404 instead of 500 for show action on unknown resource id.

Signed-off-by: Magne Land magne.land@appfolio.com
