### PR TITLE
Don't raise in ReponseTemplate#compile when nil mediatype

### DIFF
--- a/lib/praxis/response_template.rb
+++ b/lib/praxis/response_template.rb
@@ -14,12 +14,6 @@ module Praxis
       if block.parameters.any? { |(type, name)| name == :media_type && type == :keyreq } && action
         unless args.has_key? :media_type
           media_type = action.resource_definition.media_type
-          unless media_type
-            raise Exceptions::InvalidConfiguration.new(
-              "Could not default :media_type argument for response template #{@name}." +
-               " Resource #{action.resource_definition} does not have an associated mediatype and none was passed"
-            )
-          end
           args[:media_type] = media_type
         end
       end


### PR DESCRIPTION
When a response_template doesn't detect a media type, an exception is raised which results in the below error when running "rake praxis:routes":

"Praxis::Exceptions::InvalidConfiguration: Could not default :media_type argument for response template ok. Resource V1::Resources::Posts does not have an associated mediatype and none was passed"

This breaks the procedure in "Getting Started".

Fixes #28

Signed-off-by: Justin Gaylor justin@rightscale.com
