### PR TITLE
Enhance `action` request stage.

### DIFF
--- a/lib/praxis/request_stages/action.rb
+++ b/lib/praxis/request_stages/action.rb
@@ -5,10 +5,13 @@ module Praxis
       
       def execute
         response = controller.send(action.name, **request.params_hash)
-        if response.kind_of? String
+        case response
+        when String
           controller.response.body = response
-        else
+        when Praxis::Response
           controller.response = response
+        else
+          raise "Action #{action.name} in #{controller.class} returned #{response.inspect}. Only Response objects or Strings allowed."
         end  
         controller.response.request = request
         nil # Action cannot return its OK request, as it would indicate the end of the stage chain

--- a/spec/praxis/request_stages_action_spec.rb
+++ b/spec/praxis/request_stages_action_spec.rb
@@ -1,0 +1,61 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe Praxis::RequestStages::Action do
+
+  let(:controller) do
+    Class.new do
+      include Praxis::Controller
+    end.new(request)
+  end
+  
+  let(:action) { double("action", name: "foo") }  
+  let(:response){ Praxis::Responses::Ok.new }
+  let(:app){ double("App", controller: controller, action:action, request: request)}
+  let(:action_stage){ Praxis::RequestStages::Action.new(action.name,app) }  
+
+  let(:request) do
+    env = Rack::MockRequest.env_for('/instances/1?cloud_id=1&api_version=1.0')
+    env['rack.input'] = StringIO.new('something=given')
+    env['HTTP_VERSION'] = 'HTTP/1.1'
+    env['HTTP_HOST'] = 'rightscale'
+    request = Praxis::Request.new(env)
+    request.action = action
+    request
+  end
+
+
+  context '.execute' do
+    before do
+      expect(controller).to receive(action_stage.name).with(request.params_hash).and_return(controller_response)
+    end
+    let(:controller_response){ controller.response }
+    it 'should always call the right controller method' do
+      action_stage.execute
+    end
+    it 'should save the request reference inside the response' do
+      action_stage.execute
+      expect(controller.response.request).to eq(request)
+    end
+
+    context 'if the controller method returns a string' do
+      let(:controller_response){ "this is the body"}
+      it 'set the response body with it (and save the request too)' do
+        action_stage.execute
+        expect(controller.response.body).to eq("this is the body")
+      end
+    end
+    context 'if the controller method returns a response object' do
+      let(:controller_response){ Praxis::Responses::Created.new }
+      it 'set that response in the controller' do
+        action_stage.execute
+        expect(controller.response).to eq(controller_response)
+      end
+    end
+    context 'if the controller method returns neither a string or a response' do
+      let(:controller_response){ nil }
+      it 'an error is raised ' do
+        expect{ action_stage.execute }.to raise_error(/Only Response objects or Strings allowed/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Build the specs for the `action` request stage.
- Added an extra check to complain when a controller returns not a Response or a String

Signed-off-by: Josep M. Blanquer blanquer@rightscale.com
