### PR TITLE
Remove `actions` and `action` methods from controller concern.

### DIFF
--- a/lib/praxis/bootloader_stages/routing.rb
+++ b/lib/praxis/bootloader_stages/routing.rb
@@ -7,7 +7,7 @@ module Praxis
 
       def execute
         application.controllers.each do |controller|
-          controller.actions.each do |action_name, action|
+          controller.definition.actions.each do |action_name, action|
             action.routes.each do |route|
               target = target_factory(controller, action_name)
               application.router.add_route target, route
@@ -18,7 +18,7 @@ module Praxis
 
 
       def target_factory(controller, action_name)
-        action = controller.action(action_name)
+        action = controller.definition.actions.fetch(action_name)
 
         Proc.new do |request|
           request.action = action

--- a/lib/praxis/controller.rb
+++ b/lib/praxis/controller.rb
@@ -20,15 +20,6 @@ module Praxis
         definition.controller = self
         Application.instance.controllers << self
       end
-
-      def actions
-        (self.respond_to? :definition) ? definition.actions : {}
-      end
-
-      def action(name)
-        actions.fetch(name)
-      end
-
     end
 
     def initialize(request, response=Responses::Ok.new)

--- a/spec/praxis/controller_spec.rb
+++ b/spec/praxis/controller_spec.rb
@@ -32,20 +32,4 @@ describe Praxis::Controller do
     end
   end
 
-  context '.actions' do
-    it 'gets the controller actions' do
-      expect(subject.actions.keys).to match_array([:index, :show])
-      expect(subject.actions[:index]).to be_kind_of(Praxis::ActionDefinition)
-      expect(subject.actions[:index].name).to eq(:index)
-    end
-  end
-
-  context '.action' do
-    it 'gets the index action of the controller' do
-      expect(subject.action(:index)).to be_kind_of(Praxis::ActionDefinition)
-      expect(subject.action(:index).name).to eq(:index)
-    end
-  end
-
-
 end

--- a/spec/praxis/request_spec.rb
+++ b/spec/praxis/request_spec.rb
@@ -10,7 +10,7 @@ describe Praxis::Request do
     env
   end
 
-  let(:action) { Instances.actions[:show] }
+  let(:action) { Instances.definition.actions[:show] }
 
   let(:context) do
     {

--- a/spec/praxis/request_stages_validate_spec.rb
+++ b/spec/praxis/request_stages_validate_spec.rb
@@ -7,7 +7,7 @@ describe Praxis::RequestStages::Validate do
   # controller for the specs instead of creating a simple controller.
   let(:controller) { Instances }
 
-  let(:action) { controller.actions[:show] }
+  let(:action) { controller.definition.actions[:show] }
 
   let(:request) do
     env = Rack::MockRequest.env_for('/instances/1?cloud_id=1&api_version=1.0')

--- a/spec/spec_app/app/controllers/instances.rb
+++ b/spec/spec_app/app/controllers/instances.rb
@@ -56,7 +56,7 @@ class Instances < BaseClass
       headers = {
         'Status' => '201',
         'Content-Type' => Instance.identifier,
-        'Location' => self.class.action(:show).primary_route.path.expand(cloud_id: cloud_id, id: instance.id)
+        'Location' => self.class.definition.actions[:show].primary_route.path.expand(cloud_id: cloud_id, id: instance.id)
       }
 
       part = Praxis::MultipartPart.new(part_body, headers)


### PR DESCRIPTION
These methods return definition actions anyway, so it seems clearer
to have the code follow up the definition object. That is: 
- `ctrl.actions` should now be `ctrl.definition.actions`
- `ctrl.action(:name)` should now be `ctrl.definition.actions[:name]`

This opens the door to define both design and controller in a single file/class
for quick tests.
Adapted the small parts of the code to access the actions the new way.

Signed-off-by: Josep M. Blanquer blanquer@rightscale.com
