### PR TITLE
Beef up the internal server error class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,5 +24,6 @@
 * Make the system be more robust in error reporting when controllers do not return a String or a Response
 * Fix: ValidationError not setting a Content-Type header. [Issue #39](https://github.com/rightscale/praxis/issues/19)
 * Relaxed ActiveSupport version dependency (from 4 to >=3 )
+* Fix: InternalServerError not setting a Content-Type header. [Issue #42](https://github.com/rightscale/praxis/issues/42)
 
 ## 0.9 Initial release

--- a/lib/praxis.rb
+++ b/lib/praxis.rb
@@ -73,6 +73,7 @@ module Praxis
 
   # Avoid loading responses (and templates) lazily as they need to be registered in time
   require 'praxis/responses/http'
+  require 'praxis/responses/internal_server_error'
   require 'praxis/responses/validation_error'
 
   module BootloaderStages

--- a/lib/praxis/responses/http.rb
+++ b/lib/praxis/responses/http.rb
@@ -125,30 +125,6 @@ module Praxis
     end
 
 
-    # A generic error message, given when an unexpected condition was encountered and no more specific message is suitable.
-    class InternalServerError < Praxis::Response
-      self.status = 500
-
-      attr_accessor :error
-
-      def initialize(error: nil, **opts)
-        super(**opts)
-        @error = error
-      end
-
-      def format!(exception = @error) #_exception(exception)
-        if @error
-          msg = {
-            name: exception.class.name,
-            message: exception.message,
-            backtrace: exception.backtrace
-          }
-          msg[:cause] = format!(exception.cause) if exception.cause
-          @body = msg
-        end
-      end
-    end
-
     ApiDefinition.define do |api|
       self.constants.each do |class_name|
         response_class = self.const_get(class_name)

--- a/lib/praxis/responses/internal_server_error.rb
+++ b/lib/praxis/responses/internal_server_error.rb
@@ -1,0 +1,40 @@
+module Praxis
+
+  module Responses
+
+    # A generic error message, given when an unexpected condition was encountered and no more specific message is suitable.
+    class InternalServerError < Praxis::Response
+      self.status = 500
+      attr_accessor :error
+
+      def initialize(error: nil, **opts)
+        super(**opts)
+        @headers['Content-Type'] = 'application/json' #TODO: might want an error mediatype
+        @error = error
+      end
+
+      def format!(exception = @error) #_exception(exception)
+        if @error
+          msg = {
+            name: exception.class.name,
+            message: exception.message,
+            backtrace: exception.backtrace
+          }
+          msg[:cause] = format!(exception.cause) if exception.cause
+          @body = msg
+        end
+      end
+    end
+
+  end
+
+  ApiDefinition.define do |api|
+    api.response_template :internal_server_error do
+      description "When an internal server error occurs..."
+      status 500
+      media_type "application/json"
+    end
+  end
+
+end
+

--- a/spec/praxis/responses/internal_server_error_spec.rb
+++ b/spec/praxis/responses/internal_server_error_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+
+describe Praxis::Responses::InternalServerError do
+
+  context 'a basic response' do
+    subject(:response) { Praxis::Responses::InternalServerError.new }
+    it 'always sets the json content type' do
+      expect(response.name).to be(:internal_server_error)
+      expect(response.status).to be(500)
+      expect(response.body).to be_empty
+      expect(response.headers).to have_key('Content-Type')
+      expect(response.headers['Content-Type']).to eq('application/json')
+      expect(response.instance_variable_get(:@error)).to be(nil)
+    end
+  end
+
+  context '.format!' do
+    let(:error) { double('error', message: 'error message', backtrace: [1, 2], cause: cause) }
+    subject(:response) { Praxis::Responses::InternalServerError.new(error: error) }
+    before do
+      expect(response.body).to be_empty
+      response.format!
+    end
+
+    context 'without a cause' do
+      let(:cause) { nil }
+      it 'it fills message and backtrace' do
+        expect(response.body).to eq({name: error.class.name, message: error.message, backtrace: error.backtrace})
+      end
+    end
+
+    context 'with a cause' do
+      let(:cause) { Exception.new('cause message') }
+      it 'it fills message, backtrace and cause' do
+        expect(response.body.keys).to eq([:name, :message, :backtrace, :cause])
+        expect(response.body[:name]).to eq(error.class.name)
+        expect(response.body[:message]).to eq(error.message)
+        expect(response.body[:backtrace]).to eq(error.backtrace)
+        expect(response.body[:cause]).to eq({ name: cause.class.name, message: cause.message, backtrace: cause.backtrace })
+      end
+    end
+  end
+
+  context 'its response template' do
+    let(:template){ Praxis::ApiDefinition.instance.responses[:internal_server_error] }
+    it 'is registered with the ApiDefinition' do
+      expect(template).to be_kind_of(Praxis::ResponseTemplate)
+    end
+  end
+end


### PR DESCRIPTION
- Add tests for it
- Ensure we set a Content-Type header (Fixes #42)

Signed-off-by: Alistair Scott alistair@rightscale.com
