### PR TITLE
Make the error for a missing response_template name a bit more useful.

### DIFF
--- a/lib/praxis/api_definition.rb
+++ b/lib/praxis/api_definition.rb
@@ -30,7 +30,7 @@ module Praxis
 
     def response(name)
       return @responses.fetch(name) do
-        raise ArgumentError, "no response defined with name #{name.inspect}"
+        raise ArgumentError, "no response template defined with name #{name.inspect}. Are you forgetting to register it with ApiDefinition?"
       end
     end
 


### PR DESCRIPTION
Should help with #29 and #9.
