### PR TITLE
Doc browser and media type collection improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,5 +25,13 @@
 * Fix: ValidationError not setting a Content-Type header. [Issue #39](https://github.com/rightscale/praxis/issues/19)
 * Relaxed ActiveSupport version dependency (from 4 to >=3 )
 * Fix: InternalServerError not setting a Content-Type header. [Issue #42](https://github.com/rightscale/praxis/issues/42)
+* A few document browser improvements:
+	* Avoid showing certain internal type options (i.e. reference).
+	* Fixed type label cide to detect collections better, and differentiate between Attributor ones and MediaType ones.
+	* Tweaked _example.html template to be much more collapsed by default, as it is not great, but makes it easier to review.
+	* Enhanced _links.html template to use the rs-type-label, and rs-attribute-description directives.
+* Mediatype documentation improvements:
+	* Make `Links` always list its attributes when describe (never shallow)
+	* refactored MediaTypeCollection to store a member_attribute (instead of a member_type), and report it in describe much like attributor collections do.
 
 ## 0.9 Initial release

--- a/lib/api_browser/app/css/main.css
+++ b/lib/api_browser/app/css/main.css
@@ -4376,6 +4376,10 @@ body {
   body a {
     cursor: pointer; }
 
+.content dl {
+  margin-top: 0;
+  margin-bottom: 0; }
+
 .header .navbar-default {
   background-image: -ms-linear-gradient(top, #fff 0%, #f3f3f3 100%);
   background-image: -moz-linear-gradient(top, #fff 0%, #f3f3f3 100%);

--- a/lib/api_browser/app/js/directives/attribute_description.js
+++ b/lib/api_browser/app/js/directives/attribute_description.js
@@ -10,7 +10,8 @@
 
       _.forEach(scope.attribute.options, function(option, name) {
         var templatePath = 'views/directives/attribute_description/_default.html';
-
+        var skip_keys = ['reference','dsl_compiler','dsl_compiler_options'];
+        
         switch (name) {
           case 'example':
             // expects string
@@ -24,19 +25,21 @@
             break;
         }
 
-        $http.get(templatePath, { cache: $templateCache }).success(function(template) {
-          var row = $(template);
-          var rowScope = scope.$new(true);
-
-          rowScope.row = {
-            name: name,
-            value: option
-          };
-
-          $compile(row)(rowScope);
-          list.append(row);
-        });
-
+        if( ! _.contains( skip_keys, name ) ) {
+          $http.get(templatePath, { cache: $templateCache }).success(function(template) {
+            var row = $(template);
+            var rowScope = scope.$new(true);
+  
+            rowScope.row = {
+              name: name,
+              value: option
+            };
+  
+            $compile(row)(rowScope);
+            list.append(row);
+          });
+        }
+        
       })
     }
   };

--- a/lib/api_browser/app/js/directives/type_label.js
+++ b/lib/api_browser/app/js/directives/type_label.js
@@ -16,8 +16,8 @@
   var templates = {
     primitive: '<span>{{type.name}}</span>',
     type: '<a ui-sref="root.type({version: apiVersion, type: type.name})">{{type.name | resourceName}}</a>',
-    typeCollection: '<span>Collection&nbsp;[&nbsp;{{type.options.member_attribute.type.name}}&nbsp;]</a>',
-    primitiveCollection: '<span>Collection&nbsp;[&nbsp;<a ui-sref="root.type({version: apiVersion, type: type.options.member_attribute.type.name})">{{type.options.member_attribute.type.name | resourceName}}</a>&nbsp;]</span>',
+    primitiveCollection: '<span>Collection&nbsp;[&nbsp;{{type.member_attribute.type.name}}&nbsp;]</a>',
+    typeCollection: '<span>Collection&nbsp;[&nbsp;<a ui-sref="root.type({version: apiVersion, type: type.member_attribute.type.name})">{{type.member_attribute.type.name | resourceName}}</a>&nbsp;]</span>',
     link: '<span>Link&nbsp;[&nbsp;<a ui-sref="root.type({version: apiVersion, type: type.link_to})">{{type.link_to | resourceName}}</a>&nbsp;]</span>'
   };
 
@@ -29,15 +29,15 @@
     link: function(scope, element) {
 
       var template = templates.type;
-
       if (_.contains(primitives, scope.type.name)) {
         template = templates.primitive;
       }
-      else if (scope.type.name === 'Collection') {
-        if (_.contains(primitives, scope.type.options.member_attribute.type.name))
-          template = templates.typeCollection;
-        else
+      else if ( scope.type.member_attribute !== undefined ) { 
+        if ( _.contains(primitives, scope.type.member_attribute.type.name)){
           template = templates.primitiveCollection;
+        }else{
+          template = templates.typeCollection;
+				}
       }
       else if (scope.type.link_to) {
         template = templates.link;

--- a/lib/api_browser/app/sass/modules/_body.scss
+++ b/lib/api_browser/app/sass/modules/_body.scss
@@ -9,3 +9,10 @@ body {
     cursor: pointer;
   }
 }
+
+.content {
+	dl {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+}

--- a/lib/api_browser/app/views/directives/attribute_description/_example.html
+++ b/lib/api_browser/app/views/directives/attribute_description/_example.html
@@ -1,8 +1,13 @@
-﻿<dt ng-if="row.value.length < 250">example</dt>
-<dt ng-if="row.value.length >= 250">
-  <a ng-init="row.isCollapsed = true" ng-click="row.isCollapsed = !row.isCollapsed">example (click to {{row.isCollapsed? 'expand' : 'collapse'}})</a>
+﻿<dt ng-if="row.value.length < 50">example</dt> 
+<dt ng-if="row.value.length >= 50">
+	  example (<a ng-init="row.isCollapsed = true" ng-click="row.isCollapsed = !row.isCollapsed">{{row.isCollapsed? 'show' : 'hide'}}</a>)
+	</dt>
 </dt>
-<dd ng-if="row.value.length <= 50"><code>{{row.value}}</code></dd>
+
+
+<dd ng-if="row.value.length <= 50">
+	<code ng-class="{hide: false}">{{row.value}}</code>
+</dd>
 <dd ng-if="row.value.length > 50">
   <pre ng-class="{hide: row.isCollapsed}">{{row.value}}</pre>
 </dd>

--- a/lib/api_browser/app/views/directives/attribute_table_row/_links.html
+++ b/lib/api_browser/app/views/directives/attribute_table_row/_links.html
@@ -1,10 +1,11 @@
 <ng-include src="'views/directives/attribute_table_row/_default.html'" no-container></ng-include>
-<div class="row" ng-repeat="(k,v) in attribute.options.dsl_compiler_options.links">
-  <div class="col-sm-3" ng-bind-html="name + '.' + k | attributeName">
+<div class="row" ng-repeat="(attribute_name,attribute) in attribute.type.attributes">
+  <div class="col-sm-3" ng-bind-html="name + '.' + attribute_name | attributeName">
   </div>
   <div class="col-sm-2">
+		 <rs-type-label type="attribute.type"></rs-type-label>
   </div>
   <div class="col-sm-7">
-    {{v}}
+    <rs-attribute-description attribute="attribute"></rs-attribute-description>
   </div>
 </div>

--- a/lib/praxis/links.rb
+++ b/lib/praxis/links.rb
@@ -42,6 +42,10 @@ module Praxis
       self
     end
 
+    def self.describe(shallow=false)
+      super(false) # Links must always describe attributes
+    end
+    
     def self._finalize!
       super
       if @attribute

--- a/spec/praxis/media_type_collection_spec.rb
+++ b/spec/praxis/media_type_collection_spec.rb
@@ -7,6 +7,18 @@ describe Praxis::MediaTypeCollection do
 
   let(:snapshots) { example.snapshots }
 
+  subject(:media_type_collection) do
+    Class.new(Praxis::MediaTypeCollection) do
+      member_type Volume
+    end
+  end
+   
+  context '.member_type' do
+    its(:member_type){ should be(Volume) }
+    its(:member_attribute){ should be_kind_of(Attributor::Attribute) }
+    its('member_attribute.type'){ should be(Volume) }
+  end
+  
   context '.load' do
     let(:volume_data) do
       {


### PR DESCRIPTION
- Doc browser
  - Avoid showing certain internal type options (i.e. reference).
  - Fix Type label to detect collections better, and differentiate between attributor ones and higher level ones.
  - tweaked example template to be much more collapsed by default.
  - enhanced links template to use the re-type-label, and rs-attribute-description directives.
- Mediatypes
  - make Links always list its attributes when describe (never shallow)
  - refactored media_type_collection to store a member_attribute (instead of a member_type), and report it in describe much like attributor collections do.

Signed-off-by: Josep M. Blanquer blanquer@rightscale.com
