### PR TITLE
Use and test new Attributor::Hash features:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,5 +39,9 @@
   * Change: Now requires all views to be explicitly defined (and will not automatically use the underlying member view if it exists). To define a view for member element (wrapping it in a collection) one can use the new member_view.
 * Application.setup now returns the application instance so it can be chained to other application methods.
   * This allows a more compact way to rackup the application: `run Praxis::Application.instance.setup`.
+* Request headers are now backed by `Attributor::Hash` rather than (Structs)
+** Header keys are case sensitive now (although Praxis gracefully allows loading the uppercased RACK names )
+* Added tests for using `Attributor::Hash` attributes that can accept "extra" keys:
+** See the `bulk_create` action for an example applied to `Praxis::Multipart` (which derives from `Attributor::Hash`) payload [here](https://github.com/rightscale/praxis/blob/master/spec/spec_app/design/resources/instances.rb).
 	
 ## 0.9 Initial release

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'attributor' , github: 'rightscale/attributor'
+
 gem 'praxis-blueprints', github: 'rightscale/praxis-blueprints'

--- a/lib/praxis/action_definition/headers_dsl_compiler.rb
+++ b/lib/praxis/action_definition/headers_dsl_compiler.rb
@@ -2,7 +2,6 @@ module Praxis
   class ActionDefinition
     class HeadersDSLCompiler < Attributor::DSLCompiler
 
-      alias_method :orig_attribute, :attribute
       # it allows to define expectations on incoming headers. For example:
       # header :X_SpecialCookie                        => implies the header is required
       # header :X_Something, /matching_this/           => implies that if the name header exists, it should match the regexp
@@ -22,14 +21,15 @@ module Praxis
           # Defining the existence without any other options can only mean that it is required (otherwise it is a useless definition)
           options[:required] = true if options.empty?
         end
-        orig_attribute name.upcase , String, options
+        #orig_attribute name.upcase , String, options
+        key name , String, options
       end
 
-#      def attribute( name, type, **rest)
-#        raise Exceptions::InvalidConfiguration.new(
-#          "You cannot use the 'attribute' DSL inside a headers definition"
-#        )
-#      end
+      # Override the attribute to really call "key" in the hash (for temporary backwards compat)      
+      def attribute(name, attr_type=nil, **opts, &block)
+        warn "[DEPRECATION] `attribute` is deprecated when defining headers.  Please use `key` instead."
+        key(name, attr_type, **opts, &block)
+      end
 
     end
   end

--- a/lib/praxis/request.rb
+++ b/lib/praxis/request.rb
@@ -73,13 +73,8 @@ module Praxis
 
     def load_headers(context)
       return unless action.headers
-      defined_headers = action.headers.attributes.keys.each_with_object(Hash.new) do |name, hash|
-        env_name = if name == :CONTENT_TYPE || name == :CONTENT_LENGTH
-          name.to_s
-        else
-          "HTTP_#{name}"
-        end
-        hash[name] = self.env[env_name] if self.env.has_key? env_name
+      defined_headers = action.precomputed_header_keys_for_rack.each_with_object(Hash.new) do |(upper,original), hash|
+        hash[original] = self.env[upper] if self.env.has_key? upper
       end
       self.headers = action.headers.load(defined_headers, context)
     end

--- a/spec/functional_spec.rb
+++ b/spec/functional_spec.rb
@@ -9,7 +9,7 @@ describe 'Functional specs' , focus: true do
   context 'index' do
     context 'with an incorrect response_content_type param' do
       it 'fails to validate the response' do
-        get '/clouds/1/instances?response_content_type=somejunk&api_version=1.0'
+        get '/clouds/1/instances?response_content_type=somejunk&api_version=1.0', nil, 'HTTP_FOO' => "bar"
         response = JSON.parse(last_response.body)
         expect(response['name']).to eq('Praxis::Exceptions::Validation')
         expect(response["message"]).to match(/Bad Content-Type/)
@@ -120,21 +120,6 @@ describe 'Functional specs' , focus: true do
       end
     end
 
-    context 'with unknown key in form' do
-      before do
-        junk = MIME::Text.new('junk_value')
-        form.add junk, 'junk_name'
-      end
-
-      it 'returns an error' do
-        post '/clouds/1/instances/2/files?api_version=1.0', body, 'CONTENT_TYPE' => content_type
-        response = JSON.parse(last_response.body)
-        expect(response['name']).to eq('ValidationError')
-        expect(response["message"]).to match(/Unknown key received:/)
-      end
-
-    end
-
     context 'with a missing value in form' do
       let(:form) do
         form_data = MIME::Multipart::FormData.new
@@ -152,9 +137,36 @@ describe 'Functional specs' , focus: true do
         response = JSON.parse(last_response.body)
 
         expect(response['name']).to eq('ValidationError')
-        expect(response['errors']).to eq(["Attribute $.payload.get(\"destination_path\") is required"])
+        expect(response['errors']).to eq(["Attribute $.payload.key(\"destination_path\") is required"])
       end
 
+    end
+    
+    context 'with an extra key in the form' do
+      let(:form) do
+        form_data = MIME::Multipart::FormData.new
+
+        destination_path = MIME::Text.new('/etc/defaults')
+        form_data.add destination_path, 'destination_path'
+
+        text = MIME::Text.new('DOCKER_HOST=tcp://127.0.0.1:2375')
+        form_data.add text, 'file', 'docker'
+
+        # TEST EXTRA KEYS USING THE MULTIPART FORM
+        other = MIME::Text.new('I am extra')
+        form_data.add other, 'extra_thing'
+
+        form_data
+      end
+
+      let(:body) { form.body.to_s }
+      subject(:response) { JSON.parse(last_response.body) }
+      
+      before do
+        post '/clouds/1/instances/2/files?api_version=1.0', body, 'CONTENT_TYPE' => content_type
+      end
+      its(:keys){ should eq(['destination_path','file','options'])}
+      its(['options']){ should eq({"extra_thing"=>"I am extra"})}
     end
 
   end

--- a/spec/praxis/action_definition_spec.rb
+++ b/spec/praxis/action_definition_spec.rb
@@ -13,7 +13,7 @@ describe Praxis::ActionDefinition do
       version '1.0'
       routing { prefix '/api/hello_world' }
       payload { attribute :inherited, String }
-      headers { header :inherited, String }
+      headers { header "Inherited", String }
       params  { attribute :inherited, String }
     end
   end
@@ -22,7 +22,7 @@ describe Praxis::ActionDefinition do
     described_class.new('foo', resource_definition) do
       routing { get '/:one' }
       payload { attribute :two, String }
-      headers { header :X_REQUESTED_WITH, 'XMLHttpRequest' }
+      headers { header "X_REQUESTED_WITH", 'XMLHttpRequest' }
       params  { attribute :one, String }
     end
   end
@@ -34,8 +34,8 @@ describe Praxis::ActionDefinition do
     its('params.attributes')   { should have_key :inherited }
     its('payload.attributes')  { should have_key :two }
     its('payload.attributes')  { should have_key :inherited }
-    its('headers.attributes')  { should have_key :X_REQUESTED_WITH }
-    its('headers.attributes')  { should have_key :INHERITED }
+    its('headers.attributes')  { should have_key "X_REQUESTED_WITH" }
+    its('headers.attributes')  { should have_key "Inherited" }
   end
 
   context '#responses' do
@@ -83,13 +83,21 @@ describe Praxis::ActionDefinition do
   end
 
   describe '#headers' do
+    it 'is backed by a Hash' do 
+      expect(subject.headers.type < Attributor::Hash).to be(true)
+    end
+
+    it 'is has case_sensitive_load enabled' do
+      expect(subject.headers.type.options[:case_insensitive_load]).to be(true) 
+    end
+
     it 'merges in more headers' do
       subject.headers do
-        header :more
+        header "more"
       end
 
       expect(subject.headers.attributes.keys).to match_array([
-        :X_REQUESTED_WITH, :INHERITED, :MORE
+        "X_REQUESTED_WITH", "Inherited", "more"
       ])
     end
   end

--- a/spec/praxis/request_spec.rb
+++ b/spec/praxis/request_spec.rb
@@ -7,6 +7,7 @@ describe Praxis::Request do
     env['rack.input'] = rack_input
     env['CONTENT_TYPE'] = 'application/x-www-form-urlencoded'
     env['HTTP_VERSION'] = 'HTTP/1.1'
+    env['HTTP_AUTHORIZATION'] = 'Secret'
     env
   end
 
@@ -63,6 +64,19 @@ describe Praxis::Request do
 
   end
 
+  context '#load_headers' do
+
+    it 'is done preserving the original case' do
+      request.load_headers(context[:headers])
+      expect(request.headers).to match({"Authorization" => "Secret"})
+    end
+
+    it 'performs it using the memoized rack keys from the action (Hacky but...performance is important)' do
+      expect(action).to receive(:precomputed_header_keys_for_rack).and_call_original
+      request.load_headers(context[:headers])
+    end
+  end
+  
   context "performs request validation" do
     before(:each) do
       request.load_headers(context[:headers])

--- a/spec/spec_app/app/concerns/authenticated.rb
+++ b/spec/spec_app/app/concerns/authenticated.rb
@@ -5,7 +5,7 @@ module Concerns
     
     included do
       before :action do |controller|
-        auth_data = controller.request.headers.AUTHORIZATION
+        auth_data = controller.request.headers['Authorization']
         if auth_data && auth_data !~ /secret/ 
           Praxis::Responses::Unauthorized.new(body: 'Authentication info is invalid')
         end

--- a/spec/spec_app/app/controllers/instances.rb
+++ b/spec/spec_app/app/controllers/instances.rb
@@ -76,7 +76,8 @@ class Instances < BaseClass
 
     result = {
       destination_path: destination_path,
-      file: file.dump
+      file: file.dump,
+      options: request.payload['options'].dump
     }
 
     response.body = JSON.pretty_generate(result)

--- a/spec/spec_app/design/api.rb
+++ b/spec/spec_app/design/api.rb
@@ -20,7 +20,7 @@ Praxis::ApiDefinition.define do
 
   trait :authenticated do
     headers do
-      attribute :AUTHORIZATION, String, required: false
+      key "Authorization", String, required: false
     end
   end
 

--- a/spec/spec_app/design/resources/instances.rb
+++ b/spec/spec_app/design/resources/instances.rb
@@ -29,6 +29,11 @@ module ApiResources
       params do
         attribute :response_content_type, String, default: response_content_type
       end
+      headers do
+        # BOTH ARE EQUIVALENT
+        #key "FOO", String, required: true
+        header "FOO", /bar/
+      end
 
       response :ok, media_type: response_content_type
     end
@@ -108,9 +113,10 @@ module ApiResources
         attribute :id
       end
 
-      payload Praxis::Multipart do
+      payload Praxis::Multipart, allow_extra: true do
         key 'destination_path', String, required: true
-        key 'file', Attributor::FileUpload, required: true
+        key 'file', Attributor::FileUpload, required: false
+        extra 'options'
       end
 
       response :ok, media_type: 'application/json'


### PR DESCRIPTION
- header definitions are:
  *\* backed by hashes
  *\* are configured to load its keys as case insensitive
- Multipart (as part of being hashes) can now accept extra parts
