### PR TITLE
Document the new behavior of Praxis where headers are backed by Hashes

### DIFF
--- a/reference/api-definition.md
+++ b/reference/api-definition.md
@@ -11,7 +11,7 @@ Response Definitions
 
 Traits
 : A convenient way to share common DSL elements across resource definitions and
-actions (see [traits](../traits/))
+actions (see [traits](../traits/)).
 
 In the future, the ApiDefinition will allow you to define many more API-wide
 constructs.
@@ -26,7 +26,7 @@ Praxis::ApiDefinition.define
 
   trait :authenticated do
     headers do
-      header :auth_token
+      header "Auth-Token"
     end
   end
 end

--- a/reference/requests.md
+++ b/reference/requests.md
@@ -43,22 +43,45 @@ exposed through the `params` accessor.
 
 You can also obtain the complete set of headers for the given request using
 `request.headers`. This will collect the headers from the requested action and
-present them to you as a coerced and validated structure.
+present them to you as a coerced and validated structure. Unlike the `params` 
+object where attributes are accessible with dotted notation methods, the `headers` structure 
+is presented as a hash, and therefore accessible through the "[]" notation.
+
+Note that accessing header keys from the controller is case sensitive. Therefore, the string case 
+used must always match the one described in your Resource Definition headers. For
+example, let's assume that our API designer has defined the following action in some ResourceDefinition:
+
+{% highlight ruby %}
+action :create do
+  routing { post '' }
+  headers do
+    key "Authorization", String, required: true
+  end
+end
+{% endhighlight %}
+
+In our controller we would need to check the headers using `request.headers['Authorization']`. Checking `request.headers['AuThOrIzAtIoN']` wouldn't yield any value.
+
+Since the HTTP protocol defines headers are case insensitive, Praxis will allow loading 
+incoming header names to the exact case that your definition describes. That
+means that if an HTTP client send an "AuThOrIzAtIoN" header, Praxis will happily convert it to 
+an "Authorization" key in your `request.headers` hash.
 
 Please see [Resource Definitions and Actions](../resource-definitions/), for
-more information on request headers.
+more information on defining request headers in your action.
 
 ## Payload
 
 `request.payload` will return any parameters that were passed through the
-request body. Much like params and headers, the exposed payload values will be
-properly coerced and validated according to your payload spec in the
-corresponding action definition. The `request.payload` object is typically an
-`Attributor::Struct` which responds to attribute names using dotted notation
-(unless you have defined the payload block using a different type).
+request body. The exposed payload values will be properly coerced and validated according 
+to your payload spec in the corresponding action definition. Much like `request.params`, the 
+`request.payload` object is an `Attributor::Struct` which responds to attribute names 
+using dotted notation.
 
-Please see [Resource Definitions and Actions](../resource-definitions/), for
-more information on action payload.
+Note to advanced users: It is possible to override the default underlying structures for `params` 
+and `payload` (which default to `Attributor::Struct`s), as well as `headers` (which defaults to `Hash.of(key:String)`) by providing a type rather than a simple block in the action definition. Please see
+examples of that in the `bulk_create` action of the [Instances](https://github.com/rightscale/praxis/blob/master/spec/spec_app/design/resources/instances.rb) resource definition.
+.
 
 ## Action
 

--- a/reference/resource-definitions.md
+++ b/reference/resource-definitions.md
@@ -279,20 +279,55 @@ in the `params` accessor. Request body parameters will only appear in
 
 Action definitions can call out special request headers that Praxis validates
 and makes available to your actions, just like `params` and `payload`.  Use the
-`headers` method with the attributor interface to define request header
+`headers` method with the attributor interface for hashes to define request header
 expectations:
 
 {% highlight ruby %}
 action :create do
   routing { post '' }
   headers do
-    attribute :Authorization, String, required: true
+    key "Authorization", String, required: true
   end
 end
 {% endhighlight %}
 
+In addition to define a header `key` in the standard `Attributor::Hash` manner, Praxis
+also enhances the DSL with a `header` method that can shortcut the syntax for 
+certain common cases. The `header` DSL takes a String name and an optional expected value: 
+
+* if no value is passed, the only expectation is that a header with that name is received.
+* if a Regexp value is passed, the expectation is that the header value (if exists) matches it
+* if a String value is passed, the expectation is that the incoming header value (if exists) fully matches it.
+
+Any hash-like options provided as the last argument are going to be blindly passed along to the
+underlying `Attributor` types. Here are some examples of how to define header expectations:
+
+{% highlight ruby %}
+headers do	
+  # Defining a required header
+  header "Authorization"
+  # Which is equivalent to
+  key "Authorization", String, required: true
+  
+  # Defining a non-required header that must match a given regexp
+  header "Authorization", /Secret/
+  # Which is equivalent to
+  key "Authorization", String, regexp: /Secret/
+  
+  # Defining a required header that must be equal to "hello"
+  header "Authorization", "hello", required: true
+  # Which is equivalent to
+  key "Authorization", String, values: ["hello"], required: true
+end
+{% endhighlight %}
+
+Using the simplified `headers` syntax can cover most of your typical definitions, while the native 
+Hash syntax allows you to mix and match many more options. Which one to use is up to you. They
+both can perfectly coexist at the same time.
+
 The `headers` method applies to both resource definitions and actions, with the
 same rules as apply to `params` and `payload`
+
 
 #### Responses
 

--- a/reference/traits.md
+++ b/reference/traits.md
@@ -22,7 +22,7 @@ Praxis::ApiDefinition.define do
 
   trait :authenticated do
     headers do
-      header :auth_token
+      header "Auth-Token"
     end
   end
 end
@@ -34,7 +34,7 @@ trait, it would be as if you had added this params block directly to your
 action.
 
 The second example creates a trait named `authenticated`. All it does is define
-a header named `auth_token` for you to use in your actions.
+a header named `Auth-Token` for you to use in your actions.
 
 ## Using a Trait
 


### PR DESCRIPTION
Header keys are case-sensitive (i.e. need to use them in the same string-case that you defined them)

Signed-off-by: Josep M. Blanquer blanquer@rightscale.com
