### PR TITLE
Support String-typed view param for field_expansion

### DIFF
--- a/lib/praxis/extensions/field_expansion.rb
+++ b/lib/praxis/extensions/field_expansion.rb
@@ -29,7 +29,7 @@ module Praxis
 
           # Determine the view that COULD be applicable.
           view = if use_view && (view_name = request.params.view)
-            media_type.views[view_name]
+            media_type.views[view_name.to_sym]
           else
             media_type.views[:default]
           end

--- a/lib/praxis/extensions/rendering.rb
+++ b/lib/praxis/extensions/rendering.rb
@@ -20,7 +20,7 @@ module Praxis
       def display(object, include_nil: false, encoder: self.default_encoder )
         identifier = Praxis::MediaTypeIdentifier.load(self.media_type.identifier)
         identifier += encoder unless encoder.blank?
-        response.headers['Content-Type'] = identifier.to_s
+        response.headers['Content-Type'] = identifier.to_s unless response.headers['Content-Type']
         response.body = render(object, include_nil: include_nil)
         response
       rescue Praxis::Renderer::CircularRenderingError => e

--- a/spec/praxis/extensions/field_expansion_spec.rb
+++ b/spec/praxis/extensions/field_expansion_spec.rb
@@ -101,6 +101,16 @@ describe Praxis::Extensions::FieldExpansion do
         expect(expansion).to eq({id: true, name: true, links: [true]})
       end
     end
+
+    context 'supports view parameters defined as String' do
+      let(:test_attributes) { {view: true}  }
+      let(:view) { "link" }
+
+      it 'expands the fields on the view' do
+        expect(expansion).to eq({id: true, name: true, href: true})
+      end
+    end
+
   end
 
 end

--- a/spec/praxis/extensions/field_expansion_spec.rb
+++ b/spec/praxis/extensions/field_expansion_spec.rb
@@ -103,11 +103,12 @@ describe Praxis::Extensions::FieldExpansion do
     end
 
     context 'supports view parameters defined as String' do
-      let(:test_attributes) { {view: true}  }
+      let(:test_attributes) { {view: true, fields: true}  }
+      let(:fields) { 'id,href' }
       let(:view) { "link" }
 
       it 'expands the fields on the view' do
-        expect(expansion).to eq({id: true, name: true, href: true})
+        expect(expansion).to eq({id: true, href: true})
       end
     end
 


### PR DESCRIPTION
This allows using the field expansion extension even if the `view` parameter has been defined to be a `String` instead of a `Symbol` like the docs say.

Fixes #315