### PR TITLE
Build initial Rails embeddability/compat:

### DIFF
--- a/lib/praxis.rb
+++ b/lib/praxis.rb
@@ -4,6 +4,7 @@ require 'praxis-mapper'
 require 'praxis-blueprints'
 
 require 'active_support/concern'
+require 'praxis/request_superclassing'
 
 $:.unshift File.dirname(__FILE__)
 

--- a/lib/praxis/dispatcher.rb
+++ b/lib/praxis/dispatcher.rb
@@ -76,8 +76,17 @@ module Praxis
       @action = action
       @request = request
 
-      payload = {request: request, response: nil}
+      payload = {request: request, response: nil, controller: @controller}
 
+      instrumented_dispatch( payload )
+
+    ensure
+      @controller = nil
+      @action = nil
+      @request = nil
+    end
+
+    def instrumented_dispatch( payload )
       Notifications.instrument 'praxis.request.all'.freeze, payload do
         begin
           # the response stage must be the final stage in the list
@@ -100,12 +109,7 @@ module Praxis
           @application.error_handler.handle!(request, e)
         end
       end
-    ensure
-      @controller = nil
-      @action = nil
-      @request = nil
     end
-
 
     # TODO: fix for multithreaded environments
     def reset_cache!

--- a/lib/praxis/extensions/rails_compat.rb
+++ b/lib/praxis/extensions/rails_compat.rb
@@ -1,0 +1,2 @@
+require 'praxis/extensions/rails_compat/request_methods'
+require 'praxis/plugins/rails_plugin'

--- a/lib/praxis/extensions/rails_compat/request_methods.rb
+++ b/lib/praxis/extensions/rails_compat/request_methods.rb
@@ -1,14 +1,16 @@
 # Make Praxis' request derive from ActionDispatch
-if defined? Praxis::BaseRequest
+if defined? Praxis::Request
   puts "IT seems that we're trying to redefine Praxis' request parent too late."
   puts "-> try to include the Rails compat pieces earlier in the bootstrap process (before Praxis::Request is requried)"
   exit(-1)
 end
 
 begin
+  require 'praxis/request_superclassing'
+
   module Praxis
     require 'action_dispatch'
-    BaseRequest = ::ActionDispatch::Request
+    Praxis.request_superclass = ::ActionDispatch::Request
   end
   require 'praxis/request'
 end

--- a/lib/praxis/extensions/rails_compat/request_methods.rb
+++ b/lib/praxis/extensions/rails_compat/request_methods.rb
@@ -1,0 +1,17 @@
+# Make Praxis' request derive from ActionDispatch
+if defined? Praxis::BaseRequest
+  puts "IT seems that we're trying to redefine Praxis' request parent too late."
+  puts "-> try to include the Rails compat pieces earlier in the bootstrap process (before Praxis::Request is requried)"
+  exit(-1)
+end
+
+begin
+  module Praxis
+    require 'action_dispatch'
+    BaseRequest = ::ActionDispatch::Request
+  end
+  require 'praxis/request'
+end
+
+
+

--- a/lib/praxis/plugins/rails_plugin.rb
+++ b/lib/praxis/plugins/rails_plugin.rb
@@ -81,6 +81,22 @@ module Praxis
           self.response.body = body
         end
 
+        def head(status, options = {})
+          options, status = status, nil if status.is_a?(Hash)
+          status ||= options.delete(:status) || :ok
+          location = options.delete(:location)
+          content_type = options.delete(:content_type)
+
+          code = Rack::Utils::SYMBOL_TO_STATUS_CODE[status]
+          response = Praxis::Response.new(status: code, body: status.to_s, location: location)
+
+          options.each do |key, value|
+            response.headers[key.to_s.dasherize.split('-').each { |v| v[0] = v[0].chr.upcase }.join('-')] = value.to_s
+          end
+          response.content_type = content_type if content_type
+          response
+        end
+
       end
 
     end

--- a/lib/praxis/plugins/rails_plugin.rb
+++ b/lib/praxis/plugins/rails_plugin.rb
@@ -1,0 +1,88 @@
+require 'praxis/plugin'
+require 'praxis/plugin_concern'
+
+module Praxis
+  module Plugins
+    module RailsPlugin
+      include Praxis::PluginConcern
+
+      class Plugin < Praxis::Plugin
+
+        def setup!
+          require 'praxis/dispatcher'
+          enable_action_controller_instrumentation
+        end
+
+        private
+        def enable_action_controller_instrumentation
+          Praxis::Dispatcher.class_eval do
+            # Wrap the original action dispatch with a method that instruments rails-expected bits...
+            alias_method :orig_instrumented_dispatch, :instrumented_dispatch
+
+            def instrumented_dispatch( praxis_payload )
+              rails_payload = {
+                :controller => controller.class.name,
+                :action     => action.name,
+                :params     => ( (request.params) ? request.params.dump : {} ),
+                :method     => request.verb,
+                :path       => (request.fullpath rescue "unknown")
+              }
+              Praxis::Notifications.instrument("start_processing.action_controller", rails_payload.dup)
+
+              Praxis::Notifications.instrument 'process_action.action_controller' do |data|
+                begin
+                  res = orig_instrumented_dispatch(praxis_payload)
+                  # TODO: also add the db_runtime and view_runtime values...
+                  data[:status] = res[0]
+                  res
+                ensure
+                  # Append DB runtime to payload
+                  #data[:db_runtime] = 999
+                  # Append rendering time to payload
+                  #data[:view_runtime] = 123
+                end
+              end
+            end
+          end
+        end
+      end
+
+      module Request
+      end
+
+      module Controller
+        extend ActiveSupport::Concern
+
+        # Throw in some basic and expected controller methods
+
+        # Expose a rails-version of params from the controller
+        # Avoid using them explicitly in your controllers though. Use request.params object instead, as they are
+        # the Praxis ones that have been validated and coerced into the types you've defined.
+        def params
+          self.request.parameters
+        end
+
+        # Allow accessing the response headers from the controller
+        def headers
+          self.response.headers
+        end
+
+        def session
+          self.request.session
+        end
+
+        # Allow setting the status and body of the response from the controller itself.
+        def status=(code)
+          self.response.status = code
+        end
+
+        def response_body=(body)
+          #TODO: @_rendered = true # Necessary to know if to stop filter chain or not...
+          self.response.body = body
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/praxis/request.rb
+++ b/lib/praxis/request.rb
@@ -1,8 +1,6 @@
 module Praxis
 
-  BaseRequest = Object unless defined? BaseRequest
-
-  class Request < BaseRequest
+  class Request < Praxis.request_superclass
     attr_reader :env, :query
     attr_accessor :route_params, :action
 

--- a/lib/praxis/request.rb
+++ b/lib/praxis/request.rb
@@ -1,6 +1,8 @@
 module Praxis
 
-  class Request
+  BaseRequest = Object unless defined? BaseRequest
+
+  class Request < BaseRequest
     attr_reader :env, :query
     attr_accessor :route_params, :action
 

--- a/lib/praxis/request_superclassing.rb
+++ b/lib/praxis/request_superclassing.rb
@@ -1,0 +1,11 @@
+module Praxis
+  class << self
+
+    attr_writer :request_superclass
+
+    def request_superclass
+      @request_superclass || Object
+    end
+
+  end
+end

--- a/lib/praxis/response.rb
+++ b/lib/praxis/response.rb
@@ -18,7 +18,7 @@ module Praxis
       klass.status = self.status if self.status
     end
 
-    def initialize(status:self.class.status, headers:{}, body:'', location: nil)
+    def initialize(status:self.class.status, headers:{}, body: nil, location: nil)
       @name    = response_name
       @status  = status
       @headers = headers

--- a/spec/praxis/responses/internal_server_error_spec.rb
+++ b/spec/praxis/responses/internal_server_error_spec.rb
@@ -8,7 +8,7 @@ describe Praxis::Responses::InternalServerError do
     it 'always sets the json content type' do
       expect(response.name).to be(:internal_server_error)
       expect(response.status).to be(500)
-      expect(response.body).to be_empty
+      expect(response.body).to be_nil
       expect(response.headers).to have_key('Content-Type')
       expect(response.headers['Content-Type']).to eq('application/json')
       expect(response.instance_variable_get(:@error)).to be(nil)
@@ -52,7 +52,7 @@ describe Praxis::Responses::InternalServerError do
 
     subject(:response) { Praxis::Responses::InternalServerError.new(error: error) }
     before do
-      expect(response.body).to be_empty
+      expect(response.body).to be_nil
       response.format!
     end
 

--- a/spec/praxis/responses/validation_error_spec.rb
+++ b/spec/praxis/responses/validation_error_spec.rb
@@ -9,7 +9,7 @@ describe Praxis::Responses::ValidationError do
     it 'always sets the json content type' do
       expect(response.name).to be(:validation_error)
       expect(response.status).to be(400)
-      expect(response.body).to be_empty
+      expect(response.body).to be_nil
       expect(response.headers).to have_key('Content-Type')
       expect(response.headers['Content-Type']).to eq('application/json')
       expect(response.instance_variable_get(:@errors)).to be(nil)
@@ -24,7 +24,7 @@ describe Praxis::Responses::ValidationError do
     let(:exception){ nil }
     subject(:response) { Praxis::Responses::ValidationError.new(summary: summary, errors: errors, exception: exception) }
     before do
-      expect(response.body).to be_empty
+      expect(response.body).to be_nil
     end
     context 'when errors' do
       it 'it fills the errors key' do


### PR DESCRIPTION
* Refactored dispatcher methods so that instrumentation can be easily added on (but without building a flexible hook system that might decrease the performance)
* Change `Praxis:Request` so that it can be made to derive from a base class (by default derives from Object)
* Build `rails_compat` extension. Which for now only:
  * changes `Praxis:Request` to derive from `ActionDispatch::Request`
  * Will load the RailsPlugin code
* Build a `RailsPlugin` plugin which, for now, will:
  * emulate firing off the `action_controller` basic hooks (`start_processing` and `process_action`).
  * Add a few basic controller methods (which make some of the other mixing you might want to throw in your controllers happier).
 * TODO: db and view runtime values on request processing not done (i.e., not integrated with Praxis’ DB or rendering frameworks)