### PR TITLE
Allow for the new mustermann 1.x series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     * NOTE: db and view runtime values on request processing not done (i.e., not integrated with Praxis’ DB or rendering frameworks)
 * Include URI in the primitive types when generating docs and displaying them (as to not have a generic URI schema polluting the lists)
 * Loosen up the version of Rack that Praxis requires. Adapted the old MultipartParser to be compabible with Rack 2x (but in reality we should see about reusing the brand new parser that 2x comes with in the future)
+* Loosen up the version of Mustermann to allow for their latest 1.x series (which will be used by some of the latest gems with Rails 5 and friends)
 
 ## 0.21
 

--- a/praxis.gemspec
+++ b/praxis.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'praxis'
 
   spec.add_dependency 'rack', '>= 1'
-  spec.add_dependency 'mustermann', '~> 0'
+  spec.add_dependency 'mustermann', '>=0', '<=1'
   spec.add_dependency 'activesupport', '>= 3'
   spec.add_dependency 'mime', '~> 0'
   spec.add_dependency 'praxis-mapper', '~> 4.3'


### PR DESCRIPTION
 The new series might be required by some of the newer gems which might be pulled in by Rails 5 and such.

Default pattern for mustermann continues being Sinatra, which has some new features but it is backwards compatible.

Signed-off-by: Josep M. Blanquer <blanquer@gmail.com>