### PR TITLE
Full support for Tree-based generated field-selection queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Praxis Changelog
 
+## next
+- Reworked the field selection DB query generation to support full tree of eager loaded dependencies
+  - Built support for both ActiveRecord and Sequel gems
+  - Selected DB fields will include/map the defined resource properties and will always include any necessary fields on both sides of the joins for the given associations.
+  - Added a configurable option to enable debugging of those generated queries (through `Praxis::Application.instance.config.mapper.debug_queries=true`)
+
 ## 2.0.pre.1
 
 - Bring over partial functionality from praxis-mapper and remove dependency on same

--- a/lib/praxis/mapper/resource.rb
+++ b/lib/praxis/mapper/resource.rb
@@ -212,10 +212,10 @@ module Praxis::Mapper
       base_query
     end
 
-    def self.craft_field_selection_query(base_query, selectors:, resolved:) # rubocop:disable Metrics/AbcSize
+    def self.craft_field_selection_query(base_query, selectors:) # rubocop:disable Metrics/AbcSize
       if selectors && model._field_selector_query_builder_class
-        base_query = model._field_selector_query_builder_class.new(query: base_query, model: self.model,
-                                          selectors: selectors, resolved: resolved).generate
+        debug = Praxis::Application.instance.config.mapper.debug_queries
+        base_query = model._field_selector_query_builder_class.new(query: base_query, selectors: selectors).generate(debug: debug)
       end
       
       base_query

--- a/lib/praxis/mapper/sequel_compat.rb
+++ b/lib/praxis/mapper/sequel_compat.rb
@@ -1,10 +1,11 @@
 require 'active_support/concern'
 
+
 module Praxis::Mapper
   module SequelCompat
     extend ActiveSupport::Concern
 
-``    included do
+    included do
       attr_accessor :_resource
     end
 
@@ -13,11 +14,16 @@ module Praxis::Mapper
         Praxis::Extensions::SequelFilterQueryBuilder
       end
 
+      def _field_selector_query_builder_class
+        Praxis::Extensions::FieldSelection::SequelQuerySelector
+      end
+
       def _praxis_associations
         orig = self.association_reflections.clone
-
         orig.each do |k,v|
           v[:model] = v.associated_class
+          v[:local_key_columns] = local_columns_used_for_the_association(v[:type], v)
+          v[:remote_key_columns] = remote_columns_used_for_the_association(v[:type], v)
           if v.respond_to?(:primary_key)
             v[:primary_key] = v.primary_key
           else
@@ -29,6 +35,39 @@ module Praxis::Mapper
           end
         end
         orig
+      end
+
+      private
+      def local_columns_used_for_the_association(type, assoc_reflection)
+        case type
+        when :one_to_many
+          # The associated table (or middle table if many to many) will point to us by PK
+          assoc_reflection[:primary_key_columns]
+        when :many_to_one
+          # We have the FKs to the associated model
+          assoc_reflection[:keys]
+        when :many_to_many
+          # The middle table if many to many) will point to us by key (usually the PK, but not always)
+          assoc_reflection[:left_primary_keys]
+        else 
+          raise "association type #{type} not supported"
+        end
+      end
+
+      def remote_columns_used_for_the_association(type, assoc_reflection)
+        case type
+        when :one_to_many
+          # The columns in the associated table that will point back to the original association
+          assoc_reflection[:keys]
+        when :many_to_one
+          # The columns in the associated table that the children will point to (usually the PK, but not always) ??
+          [assoc_reflection.associated_class.primary_key]
+        when :many_to_many
+          # The middle table if many to many will point to us by key (usually the PK, but not always) ??
+          [assoc_reflection.associated_class.primary_key]
+        else 
+          raise "association type #{type} not supported"
+        end
       end
 
     end

--- a/lib/praxis/plugins/mapper_plugin.rb
+++ b/lib/praxis/plugins/mapper_plugin.rb
@@ -8,6 +8,21 @@ module Praxis
 
       class Plugin < Praxis::Plugin
         include Singleton
+
+        def config_key
+          :mapper
+        end
+
+        def load_config!
+          {} # override the default one, since we don't necessarily want to configure it via a yaml file.
+        end
+
+        def prepare_config!(node)
+          node.attributes do
+            attribute :debug_queries, Attributor::Boolean, default: false,
+              description: 'Weather or not to log debug information about queries executed in the build_query automation module'
+          end
+        end
       end
 
       module Controller
@@ -32,8 +47,7 @@ module Praxis
           filters = request.params.filters if request.params&.respond_to?(:filters)
           base_query = domain_model.craft_filter_query( base_query , filters: filters )
 
-          resolved = Praxis::MediaType::FieldResolver.resolve(self.media_type, self.expanded_fields)
-          base_query = domain_model.craft_field_selection_query(base_query, selectors: selector_generator.selectors, resolved: resolved)
+          base_query = domain_model.craft_field_selection_query(base_query, selectors: selector_generator.selectors)
 
           # TODO: handle pagination and ordering
           base_query

--- a/praxis.gemspec
+++ b/praxis.gemspec
@@ -51,4 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'fuubar', '~> 2'
   spec.add_development_dependency 'yard', ">= 0.9.20"
   spec.add_development_dependency 'coveralls'
+  # Just for the query selector extensions etc...
+  spec.add_development_dependency 'sequel', '~> 5'
+  spec.add_development_dependency 'activerecord', '> 4'
 end

--- a/spec/praxis/extensions/field_selection/active_record_query_selector_spec.rb
+++ b/spec/praxis/extensions/field_selection/active_record_query_selector_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+require_relative 'support/spec_resources_active_model.rb'
+
+describe Praxis::Extensions::FieldSelection::ActiveRecordQuerySelector do
+  let(:selector_fields) do
+    { 
+      name: true,
+      author: {
+        id: true,
+        books: true
+      },
+      category: {
+        name: true,
+        books: true
+      },
+      tags: {
+        name: true
+      }
+    }
+  end
+  let(:expected_select_from_to_query) do
+    # The columns to select from the top Simple model
+    [
+      :simple_name, # from the :name alias
+      :author_id, # the FK needed for the author association
+      :added_column, # from the extra column defined in the parent property
+      :category_uuid, # the FK needed for the cateory association
+      :id # We always load the primary keys
+    ]
+  end
+  let(:selector_node) { Praxis::Mapper::SelectorGenerator.new.add(ActiveBookResource,selector_fields)  }
+
+  subject(:selector) {described_class.new(query: query, selectors: selector_node) }
+  context '#generate with a mocked' do
+    let(:query) { double("Query") }
+    it 'calls the select columns for the top level, and includes the right association hashes' do      
+      expect(query).to receive(:select).with(*expected_select_from_to_query).and_return(query)
+      expected_includes = {
+        author: {
+          books: {}
+        },
+        category: {
+          books: {}
+        },
+        tags: {}
+      }
+      expect(query).to receive(:includes).with(expected_includes).and_return(query)
+      expect(subject).to_not receive(:explain_query)
+      subject.generate
+    end 
+    it 'calls the explain debug method if enabled' do
+      expect(query).to receive(:select).and_return(query)
+      expect(query).to receive(:includes).and_return(query)
+      expect(subject).to receive(:explain_query)
+      subject.generate(debug: true)      
+    end 
+  end
+
+  context '#generate with a real AR model' do
+    let(:query) { ActiveBook }
+
+    it 'calls the select columns for the top level, and includes the right association hashes' do
+      expected_includes = {
+        author: {
+          books: {}
+        },
+        category: {
+          books: {}
+        },
+        tags: {}
+      }
+      #expect(query).to receive(:includes).with(expected_includes).and_return(query)
+      expect(subject).to_not receive(:explain_query)
+      final_query = subject.generate
+      expect(final_query.select_values).to match_array(expected_select_from_to_query)
+      # Our query selector always uses a single hash tree from the top, not an array of things
+      includes_hash = final_query.includes_values.first
+      expect(includes_hash).to match(expected_includes)
+      # Also, make AR do the actual query to make sure everything is wired up correctly
+      result = final_query.to_a
+      expect(result.size).to be 2
+      book1 = result[0]
+      book2 = result[1]
+      expect(book1.author.id).to eq 11
+      expect(book1.author.books.size).to eq 1
+      expect(book1.author.books.map(&:simple_name)).to eq(['Book1'])
+      expect(book1.category.name).to eq 'cat1'
+      expect(book1.tags.map(&:name)).to match_array(['blue','red'])
+
+      expect(book2.author.id).to eq 22
+      expect(book2.author.books.size).to eq 1
+      expect(book2.author.books.map(&:simple_name)).to eq(['Book2'])
+      expect(book2.category.name).to eq 'cat2'
+      expect(book2.tags.map(&:name)).to match_array(['red'])
+    end
+
+    it 'calls the explain debug method if enabled' do
+      suppress_output do
+        # Actually make it run all the way...but suppressing the output
+        subject.generate(debug: true)
+      end
+    end 
+  end
+
+end

--- a/spec/praxis/extensions/field_selection/sequel_query_selector_spec.rb
+++ b/spec/praxis/extensions/field_selection/sequel_query_selector_spec.rb
@@ -1,0 +1,147 @@
+require 'spec_helper'
+require 'sequel'
+
+require 'praxis/extensions/field_selection/sequel_query_selector'
+
+
+describe Praxis::Extensions::FieldSelection::SequelQuerySelector do
+  class Q
+    attr_reader :object, :cols
+    def initialize
+      @object = {}
+      @cols = []
+    end
+    def eager(hash)
+      raise "we are only calling eager one at a time!" if hash.keys.size > 1
+      name = hash.keys.first
+      # Actually call the incoming proc with an instance of Q, to collect the further select/eager calls
+      @object[name] = hash[name].call(Q.new)
+      self
+    end
+    def select(*names)
+      @cols += names.map(&:column)
+      self
+    end
+    def dump
+      eagers = @object.each_with_object({}) do |(name, val), hash|
+        hash[name] = val.dump
+      end
+      {
+        columns: @cols,
+        eagers: eagers
+      }
+    end
+  end
+
+
+  # Pay the price for creating and connecting only in this spec instead in spec helper
+  # this way all other specs do not need to be slower and it's a better TDD experience
+
+  require_relative 'support/spec_resources_sequel.rb'
+  
+  let(:selector_fields) do
+    { 
+      name: true,
+      other_model: {
+        id: true
+      },
+      parent: {
+        children: true
+      },
+      tags: {
+        tag_name: true
+      }
+    }
+  end
+  let(:expected_select_from_to_query) do
+    # The columns to select from the top Simple model
+    [
+      :simple_name, # from the :name alias
+      :added_column, # from the extra column defined in the parent property
+      :id, # We always load the primary keys
+      :other_model_id, # the FK needed for the other_model association
+      :parent_id # the FK needed for the parent association
+    ]
+  end
+
+  let(:selector_node) { Praxis::Mapper::SelectorGenerator.new.add(SequelSimpleResource,selector_fields)  }
+  subject {described_class.new(query: query, selectors: selector_node) }
+
+  context 'generate' do
+    context 'using the real models and DB' do
+      let(:query) { SequelSimpleModel }
+
+      it 'calls the select columns for the top level, and includes the right association hashes' do      
+        ds = subject.generate
+        opts = ds.opts
+        # Top model is our simplemodel
+        expect(opts[:model]).to be(SequelSimpleModel)
+        selected_column_names = opts[:select].map(&:column)
+        expect(selected_column_names).to match_array(expected_select_from_to_query)
+        # 2 Eager loaded associations as well
+        expect(opts[:eager].keys).to match_array([:other_model, :parent, :tags])
+        # We can not introspect those eagers, as they are procs...but at least validate they are
+        expect(opts[:eager][:other_model]).to be_a Proc
+        expect(opts[:eager][:parent]).to be_a Proc
+        
+        # Also, let's make sure the query actually works by making Sequel attempt to retrieve it and finding the right things.
+        result = ds.all
+        # 2 simple models
+        expect(result.size).to be 2 
+        # First simple model points to other_model 11 and parent 1
+        simple_one = result.find{|i| i.id == 1}
+        expect(simple_one.other_model.id).to be 11
+        expect(simple_one.parent.id).to be 1
+        # also, its' parent in turn has 2 children (1 and 2) linked by its parent_uuid
+        expect(simple_one.parent.children.map(&:id)).to match_array([1,2])
+        # Has the blue and red tags
+        expect(simple_one.tags.map(&:tag_name)).to match_array(['blue','red'])
+
+        # second simple model points to other_model 22 and parent 2
+        simple_two = result.find{|i| i.id == 2}
+        expect(simple_two.other_model.id).to be 22
+        expect(simple_two.parent.id).to be 2
+        # also, its' parent in turn has no children (as no simple models point to it by uuid)
+        expect(simple_two.parent.children.map(&:id)).to be_empty
+        # Also has the red tag
+        expect(simple_two.tags.map(&:tag_name)).to match_array(['red'])
+      end
+      it 'calls the explain debug method if enabled' do
+        suppress_output do
+          # Actually make it run all the way...but suppressing the output
+          subject.generate(debug: true)
+        end
+      end 
+    end
+    context 'just mocking the query' do
+      let(:query) { Q.new }
+
+      it 'creates the right recursive lambdas for the eager loading' do      
+        
+        ds = subject.generate
+        result = ds.dump
+        expect(result[:columns]).to match_array(expected_select_from_to_query)
+        # 2 eager loads
+        expect(result[:eagers].keys).to match_array([:other_model, :parent, :tags])
+        # 1 - other model
+        other_model_eagers = result[:eagers][:other_model]
+        expect(other_model_eagers[:columns]).to match_array([:id])
+
+        # 2 - parent association
+        parent_eagers = result[:eagers][:parent]
+        expect(parent_eagers[:columns]).to match_array([:id,:uuid]) # uuid is necessary for the "children" assoc
+        expect(parent_eagers[:eagers].keys).to match_array([:children])
+        # 2.1 - children association off of the parent
+        parent_children_eagers = parent_eagers[:eagers][:children]
+        expect(parent_children_eagers[:columns]).to match_array([:id,:parent_uuid]) # parent_uuid is required for the assoc
+        expect(parent_children_eagers[:eagers]).to be_empty
+
+        # 3 - tags association
+        tags_eagers = result[:eagers][:tags]
+        expect(tags_eagers[:columns]).to match_array([:id, :tag_name]) # uuid is necessary for the "children" assoc
+        expect(tags_eagers[:eagers].keys).to be_empty
+        
+      end
+    end
+  end
+end

--- a/spec/praxis/extensions/field_selection/support/spec_resources_active_model.rb
+++ b/spec/praxis/extensions/field_selection/support/spec_resources_active_model.rb
@@ -1,0 +1,130 @@
+require 'active_record'
+
+require 'praxis/mapper/active_model_compat'
+
+# Creates a new in-memory DB, and the necessary tables (and mini-seeds) for the  models in this file
+def create_tables
+
+  ActiveRecord::Base.establish_connection(
+      adapter:  'sqlite3',
+      dbfile:  ':memory:',
+      database: ':memory:'
+  )
+  
+  ActiveRecord::Schema.define do
+    ActiveRecord::Migration.suppress_messages do
+      create_table :active_books do |table|
+        table.column :simple_name, :string
+        table.column :added_column, :string
+        table.column :category_uuid, :string
+        table.column :author_id, :integer
+      end
+  
+      create_table :active_authors do |table|
+        table.column :name, :string
+      end
+  
+      create_table :active_categories do |table|
+        table.column :uuid, :string
+        table.column :name, :string
+      end
+  
+      create_table :active_tags do |table|
+        table.column :name, :string
+      end
+  
+      create_table :active_taggings do |table|
+        table.column :book_id, :integer
+        table.column :tag_id, :integer
+      end
+    end
+  end
+end
+
+create_tables
+
+class ActiveBook < ActiveRecord::Base
+  include Praxis::Mapper::ActiveModelCompat
+
+  belongs_to :category, class_name: 'ActiveCategory', foreign_key: :category_uuid, primary_key: :uuid
+  belongs_to :author, class_name: 'ActiveAuthor'
+  has_many :taggings, class_name: 'ActiveTagging', foreign_key: :book_id
+  has_many :tags, class_name: 'ActiveTag', through: :taggings
+end
+
+class ActiveAuthor < ActiveRecord::Base
+  include Praxis::Mapper::ActiveModelCompat
+  has_many :books, class_name: 'ActiveBook', foreign_key: :author_id
+end
+
+class ActiveCategory < ActiveRecord::Base
+  include Praxis::Mapper::ActiveModelCompat
+  has_many :books, class_name: 'ActiveBook', primary_key: :uuid, foreign_key: :category_uuid
+end
+
+class ActiveTag < ActiveRecord::Base
+  include Praxis::Mapper::ActiveModelCompat
+end
+
+class ActiveTagging < ActiveRecord::Base
+  include Praxis::Mapper::ActiveModelCompat
+  belongs_to :book, class_name: 'ActiveBook', foreign_key: :book_id
+  belongs_to :tag, class_name: 'ActiveTag', foreign_key: :tag_id
+end
+
+
+# A set of resource classes for use in specs
+class ActiveBaseResource < Praxis::Mapper::Resource
+end
+
+class ActiveAuthorResource < ActiveBaseResource
+  model ActiveAuthor
+
+  property :display_name, dependencies: [:name]
+end
+
+class ActiveCategoryResource < ActiveBaseResource
+  model ActiveCategory
+end
+
+class ActiveTagResource < ActiveBaseResource
+  model ActiveTag
+end
+
+class ActiveBookResource < ActiveBaseResource
+  model ActiveBook
+
+  # Forces to add an extra column (added_column)...and yet another (author_id) that will serve
+  # to check that if that's already automatically added due to an association, it won't interfere or duplicate
+  property :author, dependencies: [:author, :added_column, :author_id]
+
+  property :name, dependencies: [:simple_name]
+end
+
+
+def seed_data
+  cat1 = ActiveCategory.create( id: 1 , uuid: 'deadbeef1', name: 'cat1' )
+  cat2 = ActiveCategory.create( id: 2 , uuid: 'deadbeef2', name: 'cat2' )
+  
+  author1 = ActiveAuthor.create(  id: 11, name: 'author1' )
+  author2 = ActiveAuthor.create(  id: 22, name: 'author2' )
+  
+  tag_blue = ActiveTag.create(id: 1 , name: 'blue' )
+  tag_red = ActiveTag.create(id: 2 , name: 'red' )
+
+  book1 = ActiveBook.create( id: 1 , simple_name: 'Book1', category_uuid: 'deadbeef1')
+  book1.author = author1
+  book1.category = cat1
+  book1.save
+  ActiveTagging.create(book: book1, tag: tag_blue)
+  ActiveTagging.create(book: book1, tag: tag_red)
+  
+
+  book2 = ActiveBook.create( id: 2 , simple_name: 'Book2', category_uuid: 'deadbeef1')
+  book2.author = author2
+  book2.category = cat2
+  book2.save
+  ActiveTagging.create(book: book2, tag: tag_red)
+end
+
+seed_data

--- a/spec/praxis/extensions/field_selection/support/spec_resources_sequel.rb
+++ b/spec/praxis/extensions/field_selection/support/spec_resources_sequel.rb
@@ -1,0 +1,106 @@
+require 'sequel'
+
+require 'praxis/mapper/sequel_compat'
+
+
+# Creates a new in-memory DB, and the necessary tables (and mini-seeds) for the sequel models in this file
+def create_and_seed_tables
+    sequeldb = Sequel.sqlite 
+    # sequeldb.loggers = [Logger.new($stdout)] # Uncomment to see sequel logs
+
+    sequeldb.create_table! :sequel_simple_models do
+      primary_key :id
+      String :simple_name
+      Integer :parent_id
+      String :parent_uuid
+      Integer :other_model_id
+      String :added_column
+  end
+    sequeldb.create_table! :sequel_other_models do
+      primary_key :id
+    end
+    sequeldb.create_table! :sequel_parent_models do
+      primary_key :id
+      String :uuid
+    end
+    sequeldb.create_table! :sequel_tag_models do
+      primary_key :id
+      String :tag_name
+    end
+    sequeldb.create_table! :sequel_simple_models_sequel_tag_models do
+      Integer :sequel_simple_model_id
+      Integer :tag_id
+    end
+
+    sequeldb[:sequel_parent_models] << { id: 1 , uuid: 'deadbeef1'}
+    sequeldb[:sequel_parent_models] << { id: 2 , uuid: 'deadbeef2'}
+    
+    sequeldb[:sequel_other_models] << { id: 11 }
+    sequeldb[:sequel_other_models] << { id: 22 }
+
+    sequeldb[:sequel_tag_models] << { id: 1 , tag_name: 'blue' }
+    sequeldb[:sequel_tag_models] << { id: 2 , tag_name: 'red' }
+
+    # Simple model 1 is tagged as blue and red
+    sequeldb[:sequel_simple_models_sequel_tag_models] << { sequel_simple_model_id: 1, tag_id: 1 }
+    sequeldb[:sequel_simple_models_sequel_tag_models] << { sequel_simple_model_id: 1, tag_id: 2 }
+    # Simple model 2 is tagged as red
+    sequeldb[:sequel_simple_models_sequel_tag_models] << { sequel_simple_model_id: 2, tag_id: 2 }
+
+    # It's weird to have a parent id and parent uuid (which points to different actual parents)
+    # But it allows us to check pointing to both PKs and not PK columns
+    sequeldb[:sequel_simple_models] << { id: 1 , simple_name: 'Simple1', parent_id: 1, other_model_id: 11, parent_uuid: 'deadbeef1'}
+    sequeldb[:sequel_simple_models] << { id: 2 , simple_name: 'Simple2', parent_id: 2, other_model_id: 22, parent_uuid: 'deadbeef1'}
+end
+
+create_and_seed_tables
+
+class SequelSimpleModel < Sequel::Model
+  include Praxis::Mapper::SequelCompat
+
+  many_to_one :parent, class: 'SequelParentModel'
+  many_to_one :other_model, class: 'SequelOtherModel'
+  many_to_many :tags, class: 'SequelTagModel'
+end
+
+class SequelOtherModel < Sequel::Model
+  include Praxis::Mapper::SequelCompat
+end
+
+class SequelParentModel < Sequel::Model
+  include Praxis::Mapper::SequelCompat
+  one_to_many :children, class: 'SequelSimpleModel', primary_key: :uuid, key: :parent_uuid
+end
+
+class SequelTagModel < Sequel::Model
+  include Praxis::Mapper::SequelCompat
+end
+
+
+# A set of resource classes for use in specs
+class SequelBaseResource < Praxis::Mapper::Resource
+end
+
+class SequelOtherResource < SequelBaseResource
+  model SequelOtherModel
+
+  property :display_name, dependencies: [:name]
+end
+
+class SequelParentResource < SequelBaseResource
+  model SequelParentModel
+end
+
+class SequelTagResource < SequelBaseResource
+  model SequelTagModel
+end
+
+class SequelSimpleResource < SequelBaseResource
+  model SequelSimpleModel
+
+  # Forces to add an extra column (added_column)...and yet another (parent_id) that will serve
+  # to check that if that's already automatically added due to an association, it won't interfere or duplicate
+  property :parent, dependencies: [:parent, :added_column, :parent_id]
+
+  property :name, dependencies: [:simple_name]
+end

--- a/spec/praxis/mapper/selector_generator_spec.rb
+++ b/spec/praxis/mapper/selector_generator_spec.rb
@@ -1,301 +1,293 @@
-# require 'spec_helper'
-
-# describe Praxis::Mapper::SelectorGenerator do
-#   let(:properties) { {} }
-#   let(:resource) { BlogResource }
-#   subject(:generator) {Praxis::Mapper::SelectorGenerator.new }
-
-#   before do
-#     generator.add(resource,properties)
-#   end
-
-#   let(:expected_selectors) { {} }
-
-#   context 'for a simple field' do
-#     let(:properties) { {id: true} }
-#     let(:expected_selectors) do
-#       {
-#         BlogModel => {
-#           select: Set.new([:id]),
-#           track: Set.new()
-#         }
-#       }
-#     end
-
-#     it 'generates the correct set of selectors' do
-#       generator.selectors.should eq expected_selectors
-#     end
-#   end
-
-#   context 'for a simple property' do
-#     let(:properties) { {display_name: true} }
-#     let(:expected_selectors) do
-#       {
-#         BlogModel => {
-#           select: Set.new([:name]),
-#           track: Set.new()
-#         }
-#       }
-#     end
-#     it 'generates the correct set of selectors' do
-#       generator.selectors.should eq expected_selectors
-#     end
-#   end
-
-#   context 'for an association' do
-#     let(:properties) { {owner: true} }
-#     let(:expected_selectors) do
-#       {
-#         BlogModel => {
-#           select: Set.new([:owner_id]),
-#           track: Set.new([:owner])
-#         }
-#       }
-#     end
-#     it 'generates the correct set of selectors' do
-#       generator.selectors.should eq expected_selectors
-#     end
-
-#     context 'that is many_to_many' do
-#       let(:properties) { {commented_posts: true} }
-#       let(:resource) { UserResource }
-#       let(:expected_selectors) do
-#         {
-#           CommentModel => {
-#             select: Set.new([:author_id, :post_id]),
-#             track: Set.new([:post])
-#           },
-#           UserModel => {
-#             select: Set.new([]),
-#             track: Set.new([:comments])
-#           }
-#         }
-#       end
-#       it 'generates the correct set of selectors' do
-#         generator.selectors.should eq expected_selectors
-#       end
-#     end
-
-#     context 'that is many_to_many without a :through option' do
-#       let(:properties) { {other_commented_posts: { id: true} } }
-#       let(:resource) { UserResource }
-#       let(:expected_selectors) do
-#         {
-#           PostModel => {
-#             select: Set.new([:id]),
-#             track: Set.new([])
-#           },
-#           UserModel => {
-#             select: Set.new([]),
-#             track: Set.new([:other_commented_posts])
-#           }
-#         }
-#       end
-#       it 'generates the correct set of selectors' do
-#         generator.selectors.should eq expected_selectors
-#       end
-#     end
+require 'spec_helper'
 
 
-#     context 'that uses a composite key' do
-#       let(:properties) { {composite_model: {id: true, type: true} } }
-#       let(:resource) { OtherResource }
-#       let(:expected_selectors) do
-#         {
-#           OtherModel => {
-#             select: Set.new([:composite_id,:composite_type]),
-#             track: Set.new([:composite_model])
-#           },
-#           CompositeIdModel => {
-#             select: Set.new([:id,:type]),
-#             track: Set.new
-#           }
-#         }
-#       end
-#       it 'generates the correct set of selectors' do
-#         generator.selectors.should eq expected_selectors
-#       end
-#     end
-#   end
+describe Praxis::Mapper::SelectorGenerator do
+  let(:resource) { SimpleResource }
+  subject(:generator) {described_class.new }
 
-#   context 'for a property that specifies a field from an association' do
-#     let(:properties) { {owner_email: true} }
-#     let(:expected_selectors) do
-#       {
-#         BlogModel => {
-#           select: Set.new([:owner_id]),
-#           track: Set.new([:owner])
-#         },
-#         UserModel => {
-#           select: Set.new([:email]),
-#           track: Set.new()
-#         }
-#       }
-#     end
+  context '#add' do
+    let(:resource) { SimpleResource }
+    shared_examples 'a proper selector' do
+      it { expect(generator.add(resource, fields).dump).to be_deep_equal selectors }
+    end
+    
+    context 'basic combos' do
+      context 'direct column fields' do
+        let(:fields) { {id: true, foobar: true} }
+        let(:selectors) do 
+          {
+            model: SimpleModel,
+            columns: [:id, :foobar]
+          } 
+        end
+        it_behaves_like 'a proper selector'
+      end
 
-#     it 'generates the correct set of selectors' do
-#       generator.selectors.should eq expected_selectors
-#     end
-#   end
+      context 'aliased column fields' do
+        let(:fields) { {id: true, name: true} }
+        let(:selectors) do
+          {
+            model: SimpleModel,
+            columns: [:id, :simple_name]
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end
 
-#   context 'for a simple property that requires all fields' do
-#     let(:properties) { {everything: true} }
-#     let(:expected_selectors) do
-#       {
-#         BlogModel => {
-#           select: true,
-#           track: Set.new()
-#         }
-#       }
-#     end
-#     it 'generates the correct set of selectors' do
-#       generator.selectors.should eq expected_selectors
-#     end
-#   end
+      context 'pure associations without recursion' do
+        let(:fields) { {other_model: true} }
+        let(:selectors) do
+          {
+            model: SimpleModel,
+            columns: [:other_model_id], # FK of the other_model association
+            tracks: {
+              other_model: { 
+                columns: [:id], # joining key for the association
+                model: OtherModel 
+              }
+            }
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end
 
-#   context 'for property that uses an associated property' do
-#     let(:properties) { {owner_full_name: true} }
-#     let(:expected_selectors) do
-#       {
-#         BlogModel => {
-#           select: Set.new([:owner_id]),
-#           track: Set.new([:owner])
-#         },
-#         UserModel => {
-#           select: Set.new([:first_name, :last_name]),
-#           track: Set.new()
-#         }
-#       }
-#     end
-#     it 'generates the correct set of selectors' do
-#       generator.selectors.should eq expected_selectors
-#     end
-#   end
+      context 'aliased associations without recursion' do
+        let(:fields) { {other_resource: true} }
+        let(:selectors) do
+          {
+            model: SimpleModel,
+            columns: [:other_model_id], # FK of the other_model association
+            tracks: {
+              other_model: { 
+                columns: [:id], # joining key for the association
+                model: OtherModel 
+              }
+            }
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end
+      context 'aliased associations without recursion (that map to columns and other associations)' do
+        let(:fields) { {aliased_method: true} }
+        let(:selectors) do
+          {
+            model: SimpleModel,
+            columns: [:column1, :other_model_id], # other_model_id => because of the association
+            tracks: {
+              other_model: { 
+                columns: [:id], # joining key for the association
+                model: OtherModel 
+              }
+            }
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end
 
+      context 'redefined associations that add some extra columns (would need both the underlying association AND the columns in place)' do
+        let(:fields) { {parent: true} }
+        let(:selectors) do
+          {
+            model: SimpleModel,
+            columns: [:parent_id, :added_column],
+            tracks: {
+              parent: { 
+                columns: [:id],
+                model: ParentModel
+              }
+            }
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end
 
-#   context 'for a property that requires all fields from an association' do
-#     let(:properties) { {everything_from_owner: true} }
-#     let(:expected_selectors) do
-#       {
-#         BlogModel => {
-#           select: Set.new([:owner_id]),
-#           track: Set.new([:owner])
-#         },
-#         UserModel => {
-#           select: true,
-#           track: Set.new()
-#         }
-#       }
-#     end
-#     it 'generates the correct set of selectors' do
-#       generator.selectors.should eq expected_selectors
-#     end
-#   end
+      context 'a simple property that requires all fields' do
+        let(:fields) { {everything: true} }
+        let(:selectors) do
+          {
+            model: SimpleModel,
+            columns: [:*],
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end
 
-#   context 'using a property that specifies a :through option' do
-#     let(:properties) { {recent_posts: {author: {full_name: true}}} }
-#     let(:resource) { UserResource }
-#     let(:expected_selectors) do
-#       {
-#         PostModel => {
-#           select: Set.new([:author_id, :created_at]),
-#           track: Set.new([:author])
-#         },
-#         UserModel => {
-#           select: Set.new([:first_name, :last_name]),
-#           track: Set.new([:posts])
-#         }
-#       }
-#     end
-#     it 'generates the correct set of selectors' do
-#       generator.selectors.should eq expected_selectors
-#     end
-#   end
+      context 'a simple property that requires itself' do
+        let(:fields) { {circular_dep: true} }
+        let(:selectors) do
+          {
+            model: SimpleModel,
+            columns: [:circular_dep, :column1], #allows to "expand" the dependency into itself + others
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end
 
-#   context 'with a property with a circular definition (ie, includes its own field)' do
-#     let(:resource) { PostResource }
+      context 'a simple property without dependencies' do
+        let(:fields) { {no_deps: true} }
+        let(:selectors) do
+          {
+            model: SimpleModel
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end
 
-#     let(:properties) { {id: true, slug: true} }
-#     let(:expected_selectors) do
-#       {
-#         PostModel => {
-#           select: Set.new([:id, :slug, :title]),
-#           track: Set.new
-#         }
-#       }
-#     end
-#     it 'generates the correct set of selectors' do
-#       generator.selectors.should eq expected_selectors
-#     end
-#   end
+    end
 
-#   context 'with a property without the :through option' do
-#     let(:resource) { UserResource }
-#     let(:properties) { {blogs_summary: {size: true}} }
-#     let(:expected_selectors) do
-#      {
-#        BlogModel => {
-#          select: Set.new([:owner_id]),
-#          track: Set.new()
-#        },
-#        UserModel => {
-#          select: Set.new([:id]),
-#          track: Set.new([:blogs])
-#        }
-#      }
-#     end
-#     it 'ignores any subsequent fields when generating selectors' do
-#       generator.selectors.should eq expected_selectors
-#     end
-#   end
+    context 'nested tracking' do
+      context 'pure associations follow the nested fields' do
+        let(:fields) do
+          { 
+            other_model: {
+              id: true
+            }
+          }
+        end
+        let(:selectors) do
+          {
+            model: SimpleModel,
+            columns: [:other_model_id],
+            tracks: {
+              other_model: {
+                model: OtherModel,
+                columns: [:id]
+              }
+            }
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end
 
-#   context 'for a property with no dependencies' do
-#     let(:properties) { {id: true, kind: true} }
-#     let(:expected_selectors) do
-#       {
-#         BlogModel => {
-#           select: Set.new([:id]),
-#           track: Set.new()
-#         }
-#       }
-#     end
-#     it 'generates the correct set of selectors' do
-#       generator.selectors.should eq expected_selectors
-#     end
-#   end
+      context 'Aliased resources disregard any nested fields...' do
+        let(:fields) do
+          {
+            other_resource: {
+              id: true
+            }
+          }
+        end
+        let(:selectors) do
+          {
+            model: SimpleModel,
+            columns: [:other_model_id],
+            tracks: {
+              other_model: {
+                model: OtherModel,
+                columns: [:id]
+              }
+            }
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end
+    end
 
-#   context 'with large set of properties' do
+    context 'string associations' do
+      context 'that specify a direct existing colum in the target dependency' do
+        let(:fields) { { direct_other_name: true } }
+        let(:selectors) do
+          {
+            model: SimpleModel,
+            columns: [:other_model_id],
+            tracks: {
+              other_model: {
+                model: OtherModel,
+                columns: [:id, :name]
+              }
+            }
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end
 
-#     let(:properties) do
-#       {
-#         display_name: true,
-#         owner: {
-#           id: true,
-#           full_name: true,
-#           blogs_summary: {href: true, size: true},
-#           main_blog: {id: true},
-#         },
-#         administrator: {id: true, full_name: true}
-#       }
-#     end
+      context 'that specify an aliased property in the target dependency' do
+        let(:fields) { { aliased_other_name: true } }
+        let(:selectors) do
+          {
+            model: SimpleModel,
+            columns: [:other_model_id],
+            tracks: {
+              other_model: {
+                model: OtherModel,
+                columns: [:id, :name]
+              }
+            }
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end
 
-#     let(:expected_selectors) do
-#       {
-#         BlogModel=> {
-#           select: Set.new([:id, :name, :owner_id, :administrator_id]),
-#           track: Set.new([:owner, :administrator])
-#         },
-#         UserModel=> {
-#           select: Set.new([:id, :first_name, :last_name, :main_blog_id]),
-#           track: Set.new([:blogs, :main_blog])
-#         }
-#       }
-#     end
+      context 'for a property that requires all fields from an association' do
+        let(:fields) { {everything_from_parent: true} }
+        let(:selectors) do
+          {
+            model: SimpleModel,
+            columns: [:parent_id],
+            tracks: {
+              parent: { 
+                model: ParentModel,
+                columns: [:*]
+              }
+            }
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end
+    end
 
-#     it 'generates the correct set of selectors' do
-#       generator.selectors.should eq(expected_selectors)
-#     end
+    context 'required extra select fields due to associations' do
+      context 'many_to_one' do
+        let(:fields) { {other_model: true} }
+        let(:selectors) do
+          {
+            model: SimpleModel,
+            columns: [:other_model_id], # FK of the other_model association
+            tracks: {
+              other_model: { 
+                columns: [:id],
+                model: OtherModel 
+              }
+            }
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end
+      context 'one_to_many' do
+        let(:resource) { ParentResource }
+        let(:fields) { {simple_children: true} }
+        let(:selectors) do
+          {
+            model: ParentModel,
+            columns: [:id], # No FKs in the source model for one_to_many
+            tracks: {
+              simple_children: { 
+                columns: [:parent_id],
+                model: SimpleModel 
+              }
+            }
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end      
+      context 'many_to_many' do
+        let(:resource) { OtherResource }
+        let(:fields) { {simple_models: true} }
+        let(:selectors) do
+          {
+            model: OtherModel,
+            columns: [:id], #join key in the source model for many_to_many (where the middle table points to)
+            tracks: {
+              simple_models: { 
+                columns: [:id], #join key in the target model for many_to_many (where the middle table points to)
+                model: SimpleModel
+              }
+            }
+          }
+        end
+        it_behaves_like 'a proper selector'
+      end      
 
-#   end
-
-# end
+    end
+  end
+end

--- a/spec/spec_app/app/models/person.rb
+++ b/spec/spec_app/app/models/person.rb
@@ -1,3 +1,0 @@
-# class PersonModel #< Praxis::Mapper::Model
-#   # table_name 'people'
-# end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,8 +23,19 @@ Dir["#{File.dirname(__FILE__)}/../lib/praxis/plugins/*.rb"].each do |file|
   require file
 end
 
+
 Dir["#{File.dirname(__FILE__)}/support/*.rb"].each do |file|
   require file
+end
+
+def suppress_output
+  original_stdout, original_stderr = $stdout.clone, $stderr.clone
+  $stderr.reopen File.new('/dev/null', 'w')
+  $stdout.reopen File.new('/dev/null', 'w')
+  yield
+ensure
+  $stdout.reopen original_stdout
+  $stderr.reopen original_stderr
 end
 
 RSpec.configure do |config|

--- a/spec/support/be_deep_equal_matcher.rb
+++ b/spec/support/be_deep_equal_matcher.rb
@@ -1,0 +1,39 @@
+# Copied verbatim from: https://github.com/amogil/rspec-deep-ignore-order-matcher
+
+RSpec::Matchers.define :be_deep_equal do |expected|
+  match { |actual| match? actual, expected }
+
+  failure_message do |actual|
+    "expected that #{actual} would be deep equal with #{expected}"
+  end
+
+  failure_message_when_negated do |actual|
+    "expected that #{actual} would not be deep equal with #{expected}"
+  end
+
+  description do
+    "be deep equal with #{expected}"
+  end
+
+  def match?(actual, expected)
+    return arrays_match?(actual, expected) if expected.is_a?(Array) && actual.is_a?(Array)
+    return hashes_match?(actual, expected) if expected.is_a?(Hash) && actual.is_a?(Hash)
+    expected == actual
+  end
+
+  def arrays_match?(actual, expected)
+    exp = expected.clone
+    actual.each do |a|
+      index = exp.find_index { |e| match? a, e }
+      return false if index.nil?
+      exp.delete_at(index)
+    end
+    exp.empty?
+  end
+
+  def hashes_match?(actual, expected)
+    return false unless actual.keys.sort == expected.keys.sort
+    actual.each { |key, value| return false unless match? value, expected[key] }
+    true
+  end
+end


### PR DESCRIPTION
Reworked the field selection DB query generation to support full tree of eager loaded dependencies (rather than normalizing it all at the top-level models).

  - Built support for both ActiveRecord and Sequel gems (and added actual models and in-memory Sqlite DB tests)
  - The selected DB fields will include/map the defined resource properties and will always include any necessary fields on both sides of the joins for the given associations.
  - Added a configurable option to enable debugging of those generated queries (through `Praxis::Application.instance.config.mapper.debug_queries=true`)