### PR TITLE
fix the decoding of value filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## next
 
+* Fix filters parser regression, which would incorrectly decode url-encoded values
+
 ## 2.0.pre.12
 
 * Rebuilt API filters to support a much richer syntax. One can now use ANDs and ORs (with ANDs having order precedence), as well as group them with parenthesis. The same individual filter operands are supported. For example: 'email=*@gmail.com&(friends.first_name=Joe*,Patty|friends.last_name=Smith)

--- a/lib/praxis/extensions/attribute_filtering/filtering_params.rb
+++ b/lib/praxis/extensions/attribute_filtering/filtering_params.rb
@@ -160,7 +160,8 @@ module Praxis
           return filters if filters.is_a?(native_type)
           return new if filters.nil? || filters.blank?
 
-          parsed = Parser.new.parse(CGI.unescape(filters))
+          parsed = Parser.new.parse(filters)
+          
           tree = ConditionGroup.load(parsed)
 
           rr = tree.flattened_conditions

--- a/lib/praxis/extensions/attribute_filtering/filters_parser.rb
+++ b/lib/praxis/extensions/attribute_filtering/filters_parser.rb
@@ -24,9 +24,9 @@ module Praxis
               @values = if values.empty?
                 ""
               elsif values.size == 1
-                values.first[:value].to_s
+                CGI.unescape(values.first[:value].to_s)
               else
-                values.map{|e| e[:value].to_s}
+                values.map{|e| CGI.unescape(e[:value].to_s)}
               end
             else # No values for the operand
               @name = triad[:name].to_sym
@@ -36,7 +36,7 @@ module Praxis
               else
                 # Value operand without value? => convert it to empty string
                 raise "Interesting, didn't know this could happen. Oops!" if triad[:value].is_a?(Array) && !triad[:value].empty?
-                @values = (triad[:value] == []) ? '' : triad[:value].to_s # TODO: could this be an array (or it always comes the other if)
+                @values = (triad[:value] == []) ? '' : CGI.unescape(triad[:value].to_s) # TODO: could this be an array (or it always comes the other if)
               end
             end
           end

--- a/spec/praxis/extensions/attribute_filtering/filters_parser_spec.rb
+++ b/spec/praxis/extensions/attribute_filtering/filters_parser_spec.rb
@@ -118,14 +118,23 @@ describe Praxis::Extensions::AttributeFiltering::FilteringParams::Parser do
         'cOrN.00copia.of_thinGs.42_here=1' => 'cOrN.00copia.of_thinGs.42_here=1',
       }
     end
-    context 'supports everything (except &|(),) for values' do
+    context 'supports everything (except &|(),) for values (even without encoding..not allowed, but just to ensure the parser does not bomb)' do
       it_behaves_like 'round-trip-properly', {
         'v=1123' => 'v=1123',
         'v=*foo*' => 'v=*foo*',
         'v=*^%$#@!foo' => 'v=*^%$#@!foo',
-        'v=_-+=\{}"?:><' => 'v=_-+=\{}"?:><',
-        'v=_-+=\{}"?:><,another_value!' => 'v=[_-+=\{}"?:><,another_value!]',
+        'v=_-=\{}"?:><' => 'v=_-=\{}"?:><',
+        'v=_-=\{}"?:><,another_value!' => 'v=[_-=\{}"?:><,another_value!]',
       }
     end
+    context 'properly handles url-encoded values' do
+      it_behaves_like 'round-trip-properly', {
+        "v=#{CGI.escape('1123')}" => 'v=1123',
+        "v=#{CGI.escape('*foo*')}" => 'v=*foo*',
+        "v=#{CGI.escape('*^%$#@!foo')}" => 'v=*^%$#@!foo',
+        "v=#{CGI.escape('~!@#$%^&*()_+-={}|[]\:";\'<>?,./`')}" => 'v=~!@#$%^&*()_+-={}|[]\:";\'<>?,./`',
+        "v=#{CGI.escape('_-+=\{}"?:><')},#{CGI.escape('another_value!')}" => 'v=[_-+=\{}"?:><,another_value!]',
+      }
+    end 
   end
 end


### PR DESCRIPTION
* Before the fix, the whole filters string was decoded, where only the values should
* when multi-value filters used, only the individual values must be encoded/decoded as well, not the separating commas