### PR TITLE
Fix eager loading for root where clauses

### DIFF
--- a/bin/praxis
+++ b/bin/praxis
@@ -9,6 +9,12 @@ rescue Bundler::GemfileNotFound
   # no-op: we might be installed as a system gem
 end
 
+if ARGV[0] == "version"
+  require 'praxis/version'
+  puts "Praxis version #{Praxis::VERSION}"
+  exit 0
+end
+
 if ["routes","docs","console"].include? ARGV[0]
   require 'rake'
   require 'praxis'


### PR DESCRIPTION
avoids adding a `.references` call to the query being constructed for our filters, ONLY WHEN the condition is for our root table (need to add the other references for any joined tables to get the aliases right).
Adding the root table as a reference wil make AR to eager load it all, as it does not match that reference name to any of the already joined tables, and therefore will think the query needs to eager load them all, as the condition will be referencing some of them...