### PR TITLE
Filters fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next
 
+* Changed the Parameter Filtering to use left outer joins (and extra conditions), to allow for the proper results when OR clauses are involved in certain configurations.
+* Built support for allowing filtering directly on associations using `!` and `!!` operators. This allows to filter results where 
+there are no associated rows (`!!`) or if there are some associated rows (`!`)
 ## 2.0.pre.16
 
 * Updated `Resource.property` signature to only accept known named arguments (`dependencies` and `though` at this time) to spare anyone else from going insane wondering why their `depednencies` aren't working.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## next
 
+## 2.0.pre.17
 * Changed the Parameter Filtering to use left outer joins (and extra conditions), to allow for the proper results when OR clauses are involved in certain configurations.
 * Built support for allowing filtering directly on associations using `!` and `!!` operators. This allows to filter results where 
 there are no associated rows (`!!`) or if there are some associated rows (`!`)
+* Allow implicit definition of `filters_mapping` for filter names that match top-level associations of the model (i.e., like we do for the columns)
 ## 2.0.pre.16
 
 * Updated `Resource.property` signature to only accept known named arguments (`dependencies` and `though` at this time) to spare anyone else from going insane wondering why their `depednencies` aren't working.

--- a/lib/praxis/extensions/attribute_filtering/active_record_filter_query_builder.rb
+++ b/lib/praxis/extensions/attribute_filtering/active_record_filter_query_builder.rb
@@ -152,7 +152,8 @@ module Praxis
         def _mapped_filter(name)
           target = @filters_map[name]
           unless target
-            if @model.attribute_names.include?(name.to_s)
+            filter_name = name.to_s
+            if (@model.attribute_names + @model.reflections.keys).include?(filter_name)
               # Cache it in the filters mapping (to avoid later lookups), and return it.
               @filters_map[name] = name
               target = name

--- a/lib/praxis/version.rb
+++ b/lib/praxis/version.rb
@@ -1,3 +1,3 @@
 module Praxis
-  VERSION = '2.0.pre.16'
+  VERSION = '2.0.pre.17'
 end

--- a/spec/praxis/extensions/support/spec_resources_active_model.rb
+++ b/spec/praxis/extensions/support/spec_resources_active_model.rb
@@ -122,8 +122,6 @@ class ActiveBookResource < ActiveBaseResource
     'category.books.taggings.label': 'category.books.taggings.label',
     'primary_tags': 'primary_tags',
     'category.books.taggings': 'category.books.taggings',
-    'tags': 'tags',
-    'category': 'category',
   )
   # Forces to add an extra column (added_column)...and yet another (author_id) that will serve
   # to check that if that's already automatically added due to an association, it won't interfere or duplicate

--- a/spec/praxis/extensions/support/spec_resources_active_model.rb
+++ b/spec/praxis/extensions/support/spec_resources_active_model.rb
@@ -120,6 +120,10 @@ class ActiveBookResource < ActiveBaseResource
     'category.books.name': 'category.books.simple_name',
     'category.books.taggings.tag_id': 'category.books.taggings.tag_id',
     'category.books.taggings.label': 'category.books.taggings.label',
+    'primary_tags': 'primary_tags',
+    'category.books.taggings': 'category.books.taggings',
+    'tags': 'tags',
+    'category': 'category',
   )
   # Forces to add an extra column (added_column)...and yet another (author_id) that will serve
   # to check that if that's already automatically added due to an association, it won't interfere or duplicate

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ require 'simplecov'
 SimpleCov.start 'praxis'
 
 require 'pry'
+require 'pry-byebug'
 
 require 'praxis'
 


### PR DESCRIPTION
Switch filters to use left outer joins with an extra condition for the joined row (this fixes certain incorrect combination of association conditions with ORs, where inner joins would have discarded valid rows to apply where clauses)

Built in existence (and non-existence) of associated rows in filters using the same ! and !! operators