### PR TITLE
Implicit filters_mapping entries for existing column and association paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   * The new `any` DSL allows you to define which final leaf attribute to always allow, and with which operators and/or fuzzy restrictions.
   * For example, you can add `any updated_at, using: ['>','<']` which would allow the type to accept filters like `updated_at>2000-01-01`, or any existing nested fields like `posts.comments.updated_at>2000-01-01`
   * Note that the path of attributes passed in, will still need to exist and will be validated. Also, you still need to make sure that you have the right `filters_mapping` defined in your resources.
-
+* Changed `filters_mapping` to allow implicitly any filter path that is a valid representation of existing columns and associations. I.e., you do not have to explicitly define long nested filters that correspond to the same underlying path of associations and columns.
 ## 2.0.pre.18
 * Upgraded to newest Attributor, which cleans up the required: true semantics to only work on keys, and introduces null: true for nullability of values (independent from presence of keys or not)
 * Fixed a selector generator bug that would occur when using deep nested resource dependencies as strings 'foo.bar.baz.bam'. In this cases only partial tracking of relationships would be built, which could cause to not fully eager load DB queries.

--- a/spec/praxis/extensions/support/spec_resources_active_model.rb
+++ b/spec/praxis/extensions/support/spec_resources_active_model.rb
@@ -102,26 +102,12 @@ class ActiveBookResource < ActiveBaseResource
   model ActiveBook
 
   filters_mapping(
-    id: :id,
-    # category_uuid: :category_uuid  #NOTE: we do not need to define same-name-mappings if they exist
     'fake_nested.name': 'simple_name',
     'name': 'simple_name',
     'name_is_not': lambda do |spec| # Silly way to use a proc, but good enough for testing
       { name: :simple_name, value: spec[:value] , op: '!=' } # Can be an array for multiple conditions as well
       end,
-    'author.id': 'author.id',
-    'author.name': 'author.name',
-    'taggings.label': 'taggings.label',
-    'taggings.tag_id': 'taggings.tag_id',
-    'taggings.tag.taggings.tag_id': 'taggings.tag.taggings.tag_id',
-    'tags.name': 'tags.name',
-    'primary_tags.name': 'primary_tags.name',
-    'category.name': 'category.name',
     'category.books.name': 'category.books.simple_name',
-    'category.books.taggings.tag_id': 'category.books.taggings.tag_id',
-    'category.books.taggings.label': 'category.books.taggings.label',
-    'primary_tags': 'primary_tags',
-    'category.books.taggings': 'category.books.taggings',
   )
   # Forces to add an extra column (added_column)...and yet another (author_id) that will serve
   # to check that if that's already automatically added due to an association, it won't interfere or duplicate

--- a/tasks/thor/templates/generator/example_app/app/v1/resources/user.rb
+++ b/tasks/thor/templates/generator/example_app/app/v1/resources/user.rb
@@ -5,14 +5,6 @@ module V1
     class User < Base
       model ::User
 
-      # Mappings for the allowed filters
-      filters_mapping(
-        'uuid': 'uuid',
-        'first_name': 'first_name',
-        'last_name': 'last_name',
-        'email': 'email'
-      )
-
       # To compute the full_name (method below) we need to load first and last names from the DB
       property :full_name, dependencies: %i[first_name last_name]
 

--- a/tasks/thor/templates/generator/scaffold/implementation/resources/item.rb
+++ b/tasks/thor/templates/generator/scaffold/implementation/resources/item.rb
@@ -6,9 +6,8 @@ module <%= version_module %>
       model ::<%= singular_class %> # Change it if it maps to a different DB model class
 
       # Define the name mapping from API filter params, to model attribute/associations
-      # when they aren't 1:1
+      # when they aren't 1:1 the same
       # filters_mapping(
-      #   'name': 'name',
       #   'label': 'association.label_name'
       # )
 


### PR DESCRIPTION
allow same-path filters to be allowed in `filters_mapping` without having to explicitly list them