### PR TITLE
Resource .reload and memoization fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Praxis Changelog
 
 ## next
+* Introduced a method to reload a Resouce (.reload), which will clear the memoized values and call record.reload as well
 * Open API Generation enhancements:
   * Fixed type discovery (where some types wouldn't be included in the output)
   * Changed the generation to output named types into components, and use `$ref` to point to them whenever appropriate

--- a/spec/praxis/mapper/resource_spec.rb
+++ b/spec/praxis/mapper/resource_spec.rb
@@ -133,6 +133,19 @@ describe Praxis::Mapper::Resource do
       allow(record).to receive(:other_model).and_return(other_record)
       expect(resource.other_resource).to be(SimpleResource.new(record).other_resource)
     end
+
+    it 'memoizes result of related associations' do
+      expect(record).to receive(:parent).once.and_return(parent_record)
+      expect(resource.parent).to be(resource.parent)
+    end
+
+    it 'can clear memoization' do
+      expect(record).to receive(:parent).twice.and_return(parent_record)
+
+      expect(resource.parent).to be(resource.parent) # One time only calling the record parent method
+      resource.clear_memoization
+      expect(resource.parent).to be(resource.parent) # One time only time calling the record parent method after the reset
+    end
   end
 
   context '.wrap' do


### PR DESCRIPTION
Introduced a method to reload a Resource (.reload), which will clear the memoized values and call record.reload as well