### PR TITLE
Support for large parameters in GET requests (through a sister proxied POST action)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rubocop'
-
+gem 'attributor', path: '/Users/blanquer/dev/praxis/attributor'
 group :test do
   gem 'builder'
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rubocop'
-gem 'attributor', path: '/Users/blanquer/dev/praxis/attributor'
+
 group :test do
   gem 'builder'
 

--- a/lib/praxis/action_definition.rb
+++ b/lib/praxis/action_definition.rb
@@ -354,8 +354,8 @@ module Praxis
       end
 
       cloned._internal_set(
-        payload: cloned.params.duplicate(type: params.type.slice_clone(*params_in_query)),
-        params: cloned.params.duplicate(type: params.type.slice_clone(*params_in_route))
+        payload: cloned.params.duplicate(type: params.type.clone.slice!(*params_in_query)),
+        params: cloned.params.duplicate(type: params.type.clone.slice!(*params_in_route))
       )
       cloned.sister_get_action = self
       self.sister_post_action = cloned

--- a/lib/praxis/action_definition.rb
+++ b/lib/praxis/action_definition.rb
@@ -12,7 +12,7 @@
 module Praxis
   class ActionDefinition
     attr_reader :endpoint_definition, :api_definition, :route, :responses, :traits
-    
+
     # opaque hash of user-defined medata, used to decorate the definition,
     # and also available in the generated JSON documents
     attr_reader :metadata
@@ -333,10 +333,10 @@ module Praxis
       raise "Only GET actions support the 'enable_large_params_proxy_action' DSL. Action #{action_name} is a #{rt.verb}" unless route.verb == 'GET'
 
       cloned.instance_eval do
-        routing {
+        routing do
           # Double slash, as we do know the complete prefixed orig path at this point and we don't want the prefix to be applied again...
           post "/#{at}"
-        }
+        end
       end
 
       # Payload
@@ -345,7 +345,7 @@ module Praxis
       route_params = route.path.named_captures.keys.collect(&:to_sym)
       params_in_route = []
       params_in_query = []
-      cloned.params.type.attributes.each do |k, val|
+      cloned.params.type.attributes.each do |k, _val|
         if route_params.include? k
           params_in_route.push k
         else

--- a/lib/praxis/action_definition.rb
+++ b/lib/praxis/action_definition.rb
@@ -316,8 +316,8 @@ module Praxis
       metadata[:doc_visibility] = :none
     end
 
-    def create_post_version
-      self.sister_post_action = true # Just true to mark it for now (needs to be lazily evaled)
+    def enable_large_params_proxy_action(at: true)
+      self.sister_post_action = at # Just true to mark it for now (needs to be lazily evaled)
     end
 
     # [DEPRECATED] - Warn of the change of method name for the transition
@@ -325,23 +325,22 @@ module Praxis
       raise 'Praxis::ActionDefinition does not use `resource_definition` any longer. Use `endpoint_definition` instead.'
     end
 
-    def clone_action_as_post
+    def clone_action_as_post(at:)
       action_name = name
       cloned = clone_action_as(name: "#{action_name}_with_post")
-    
-      # route
-      raise "Only GET actions support the 'create_post_version' DSL. Action #{action_name} is a #{rt.verb}" unless route.verb == 'GET'
 
-      orig_path = @routing_config.route.prefixed_path
+      # route
+      raise "Only GET actions support the 'enable_large_params_proxy_action' DSL. Action #{action_name} is a #{rt.verb}" unless route.verb == 'GET'
+
       cloned.instance_eval do
         routing {
           # Double slash, as we do know the complete prefixed orig path at this point and we don't want the prefix to be applied again...
-          post "/#{orig_path}/actions/#{action_name}"
+          post "/#{at}"
         }
       end
 
       # Payload
-      raise "Using create_post_version for an action requires the GET payload to be empty. Action #{name} has a payload defined" unless payload.nil?
+      raise "Using enable_large_params_proxy_action for an action requires the GET payload to be empty. Action #{name} has a payload defined" unless payload.nil?
 
       route_params = route.path.named_captures.keys.collect(&:to_sym)
       params_in_route = []

--- a/lib/praxis/bootloader_stages/routing.rb
+++ b/lib/praxis/bootloader_stages/routing.rb
@@ -13,10 +13,10 @@ module Praxis
         end
 
         def call(request)
-          request.action = @action
           dispatcher = Dispatcher.current(application: @application)
-
-          dispatcher.dispatch(@controller, @action, request)
+          # Switch to the sister get action if configured that way
+          action = @action.sister_get_action || @action
+          dispatcher.dispatch(@controller, action, request)
         end
       end
 

--- a/lib/praxis/dispatcher.rb
+++ b/lib/praxis/dispatcher.rb
@@ -69,6 +69,7 @@ module Praxis
 
     def dispatch(controller_class, action, request)
       @controller = controller_class.new(request)
+      request.action = action
       @action = action
       @request = request
 

--- a/lib/praxis/docs/open_api/schema_object.rb
+++ b/lib/praxis/docs/open_api/schema_object.rb
@@ -47,9 +47,7 @@ module Praxis
               props = type.attributes.transform_values.with_index do |definition, index|
                 # if type has an attribute in its requirements all, then it should be marked as required here
                 field_name = type.attributes.keys[index]
-                if required_attributes.include?(field_name)
-                  definition.options.merge!(required: true)
-                end
+                definition.options.merge!(required: true) if required_attributes.include?(field_name)
                 OpenApi::SchemaObject.new(info: definition).dump_schema(allow_ref: true, shallow: shallow)
               end
               h = { type: :object, properties: props } # TODO: Example?
@@ -68,9 +66,7 @@ module Praxis
             h[:enum] = h[:enum] + [nil] if h[:enum] && !h[:enum].include?(nil)
           end
           # Required: Mostly for request bodies
-          if @attribute_options[:required]
-            h[:required] = true
-          end
+          h[:required] = true if @attribute_options[:required]
 
           h
 

--- a/lib/praxis/endpoint_definition.rb
+++ b/lib/praxis/endpoint_definition.rb
@@ -225,10 +225,21 @@ module Praxis
 
         action = ActionDefinition.new(name, self, &block)
         if action.sister_post_action
+          post_path = \
+            if action.sister_post_action == true
+              "#{action.route.prefixed_path}/actions/#{action.name}"
+            elsif action.sister_post_action.start_with?('//')
+              action.sister_post_action # Avoid appending prefix
+            else
+              # Make sure to cleanup the leading '/' if any, as we're always adding it below
+              cleaned_path = action.sister_post_action.start_with?('/') ? action.sister_post_action[1..-1] : action.sister_post_action
+              "#{action.route.prefixed_path}/#{cleaned_path}"
+            end
+
           # Save the finalization of the twin POST actions once we've loaded the endpoint definition
           on_finalize do
             # Create the sister POST action with a payload matching the original params
-            post_action = action.clone_action_as_post
+            post_action = action.clone_action_as_post(at: post_path)
             @actions[post_action.name] = post_action
           end
         end

--- a/lib/praxis/endpoint_definition.rb
+++ b/lib/praxis/endpoint_definition.rb
@@ -223,7 +223,16 @@ module Praxis
         raise ArgumentError, 'can not create ActionDefinition without block' unless block_given?
         raise ArgumentError, "Action names must be defined using symbols (Got: #{name} (of type #{name.class}))" unless name.is_a? Symbol
 
-        @actions[name] = ActionDefinition.new(name, self, &block)
+        action = ActionDefinition.new(name, self, &block)
+        if action.sister_post_action
+          # Save the finalization of the twin POST actions once we've loaded the endpoint definition
+          on_finalize do
+            # Create the sister POST action with a payload matching the original params
+            post_action = action.clone_action_as_post
+            @actions[post_action.name] = post_action
+          end
+        end
+        @actions[name] = action
       end
 
       def description(text = nil)

--- a/lib/praxis/tasks/routes.rb
+++ b/lib/praxis/tasks/routes.rb
@@ -14,18 +14,20 @@ namespace :praxis do
     rows = []
     Praxis::Application.instance.endpoint_definitions.each do |endpoint_definition|
       endpoint_definition.actions.each do |name, action|
+        ctrl_method = action.sister_get_action ? action.sister_get_action.name : name
         method = begin
-          endpoint_definition.controller.instance_method(name)
+          endpoint_definition.controller.instance_method(ctrl_method)
         rescue StandardError
           nil
         end
 
-        method_name = method ? "#{method.owner.name}##{method.name}" : 'n/a'
+        implementation = method ? "#{method.owner.name}##{method.name}" : 'n/a'
+        implementation = "Proxied to -> #{implementation}" if action.sister_get_action
 
         row = {
           resource: endpoint_definition.name,
           action: name,
-          implementation: method_name
+          implementation: implementation
         }
 
         if action.route

--- a/praxis.gemspec
+++ b/praxis.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'praxis'
 
   spec.add_dependency 'activesupport', '>= 3'
-  spec.add_dependency 'attributor', '>= 6.2'
+  spec.add_dependency 'attributor', '>= 6.3'
   spec.add_dependency 'mime', '~> 0'
   spec.add_dependency 'mustermann', '>=1.1'
   spec.add_dependency 'rack', '>= 1'

--- a/spec/praxis/action_definition_spec.rb
+++ b/spec/praxis/action_definition_spec.rb
@@ -292,59 +292,36 @@ describe Praxis::ActionDefinition do
     end
   end
 
-  context 'create_post_version' do
+  context 'enable_large_params_proxy_action' do
     it 'exposes the add_post_equivalent boolean' do
       subject.instance_eval do
-        create_post_version
+        enable_large_params_proxy_action
       end
       expect(subject.sister_post_action).to be_truthy
     end
-    it 'does NOT expose the add_post_equivalent boolean when create_post_version is not called' do
-      expect(subject).to_not receive(:create_post_version)
+    it 'does NOT expose the add_post_equivalent boolean when enable_large_params_proxy_action is not called' do
+      expect(subject).to_not receive(:enable_large_params_proxy_action)
       expect(subject.sister_post_action).to be_nil
     end
   end
 
   context 'creating a duplicate action with POST' do
-    let(:action_name) { :index }
-    let(:endpoint_definition) do
-      Class.new do
-        include Praxis::EndpointDefinition
-
-        def self.name
-          'FooBar'
-        end
-
-        version '1.0'
-        prefix '/foobars/hello_world'
-        action_defaults do
-          headers { header 'Inherited', String }
-          params  { attribute :inherited, String }
-        end
-      end
-    end
-    let(:action) do
-      Praxis::ActionDefinition.new(action_name, endpoint_definition) do
-        routing { get '/:one' }
-        headers { header 'X_REQUESTED_WITH', 'XMLHttpRequest' }
-        params  { attribute :one, String }
-        response :ok, media_type: SpecMediaType, headers: { 'Foo' => 'Bar' }, location: %r{/some/thing}
-      end
-    end
-    subject { action.clone_action_as_post }
+    let(:action) { PeopleResource.actions[:show]}
+    let(:post_action_path) { action.route.path.to_s + "/actions/#{action.name}" }
+    subject { action.clone_action_as_post(at: post_action_path) }
 
     it 'changes the route to a post and well-known route' do
       route = subject.route
       expect(route.verb).to eq('POST')
-      expect(route.path.to_s).to eq(action.route.path.to_s + "/actions/#{action_name}")
+      expect(route.path.to_s).to eq(post_action_path)
     end
     it 'sets the name postfixed with "with_post"' do
-      expect(subject.name).to eq("#{action_name}_with_post".to_sym)
+      expect(subject.name).to eq("#{action.name}_with_post".to_sym)
     end
 
     it 'sets the payload to contain all the original param ones, except the required URL ones' do
-      expect(subject.payload.attributes.keys).to eq(action.params.attributes.keys - [:one])
-      expect(subject.params.attributes.keys).to eq([:one])
+      expect(subject.payload.attributes.keys).to eq(action.params.attributes.keys - [:id])
+      expect(subject.params.attributes.keys).to eq([:id])
     end
 
     it 'keeps the same headers and response definitions' do
@@ -357,6 +334,7 @@ describe Praxis::ActionDefinition do
       expect(action.sister_post_action).to be(subject)
     end
   end
+
   context 'with a base_path and base_params on ApiDefinition' do
     # Without getting a fresh new ApiDefinition it is very difficult to test stuff using the Singleton
     # So for some tests we're gonna create a new instance and work with it to avoid the singleton issues

--- a/spec/praxis/action_definition_spec.rb
+++ b/spec/praxis/action_definition_spec.rb
@@ -306,7 +306,7 @@ describe Praxis::ActionDefinition do
   end
 
   context 'creating a duplicate action with POST' do
-    let(:action) { PeopleResource.actions[:show]}
+    let(:action) { PeopleResource.actions[:show] }
     let(:post_action_path) { action.route.path.to_s + "/actions/#{action.name}" }
     subject { action.clone_action_as_post(at: post_action_path) }
 

--- a/spec/praxis/endpoint_definition_spec.rb
+++ b/spec/praxis/endpoint_definition_spec.rb
@@ -12,7 +12,7 @@ describe Praxis::EndpointDefinition do
 
   its(:prefix) { should eq('/people') }
 
-  its(:actions) { should have(4).items }  # Two real actions, and two post versions of the GET
+  its(:actions) { should have(4).items } # Two real actions, and two post versions of the GET
   its(:metadata) { should_not have_key(:doc_visibility) }
 
   context '.describe' do

--- a/spec/praxis/endpoint_definition_spec.rb
+++ b/spec/praxis/endpoint_definition_spec.rb
@@ -12,7 +12,7 @@ describe Praxis::EndpointDefinition do
 
   its(:prefix) { should eq('/people') }
 
-  its(:actions) { should have(4).items }  # Two real actions, and twp post version of the GET
+  its(:actions) { should have(4).items }  # Two real actions, and two post versions of the GET
   its(:metadata) { should_not have_key(:doc_visibility) }
 
   context '.describe' do
@@ -21,7 +21,7 @@ describe Praxis::EndpointDefinition do
     its([:description]) { should eq(endpoint_definition.description) }
     its([:media_type]) { should eq(endpoint_definition.media_type.describe(true)) }
 
-    its([:actions]) { should have(4).items }  # Two real actions, and twp post version of the GET
+    its([:actions]) { should have(4).items }  # Two real actions, and two post versions of the GET
     its([:metadata]) { should be_kind_of(Hash) }
     its([:traits]) { should eq [:test] }
     it { should_not have_key(:parent) }
@@ -87,13 +87,11 @@ describe Praxis::EndpointDefinition do
           expect(endpoint_definition.actions[:index_with_post].route.prefixed_path).to eq('/people/some/custom/path')
         end
       end
-        
+
       it 'it sets its payload to match the original action params (except any params in the URL path)' do
         payload_for_show_with_post = endpoint_definition.actions[:show_with_post].payload.attributes
         params_for_show = endpoint_definition.actions[:show].params.attributes
         expect(payload_for_show_with_post.keys).to eq(params_for_show.keys - [:id])
-
-        # params_for_show_with_post = endpoint_definition.actions[:show_with_post].params.attributes
       end
       it 'it sets its params to only contain the the original action params that were in the URL' do
         params_for_show_with_post = endpoint_definition.actions[:show_with_post].params.attributes

--- a/spec/support/spec_endpoint_definitions.rb
+++ b/spec/support/spec_endpoint_definitions.rb
@@ -28,9 +28,13 @@ class PeopleResource
     routing do
       get ''
     end
+    params do
+      attribute :filters, String
+    end
   end
 
   action :show do
+    create_post_version # Create an equivalent action named 'show_with_post' with the payload matching this action's parameters (except :id)
     description 'show description'
     routing do
       get '/:id'

--- a/spec/support/spec_endpoint_definitions.rb
+++ b/spec/support/spec_endpoint_definitions.rb
@@ -24,6 +24,7 @@ class PeopleResource
   prefix '/people'
 
   action :index do
+    enable_large_params_proxy_action at: '/some/custom/path'
     description 'index description'
     routing do
       get ''
@@ -34,7 +35,7 @@ class PeopleResource
   end
 
   action :show do
-    create_post_version # Create an equivalent action named 'show_with_post' with the payload matching this action's parameters (except :id)
+    enable_large_params_proxy_action # Create an equivalent action named 'show_with_post' with the payload matching this action's parameters (except :id)
     description 'show description'
     routing do
       get '/:id'


### PR DESCRIPTION
This PR introduces a new action dsl `enable_large_params_proxy_action` for GET verb actions.
When used two things will happen:
  * A new POST verb equivalent action will be defined:
    * It will have a `payload` matching the shape of the original GET's `params` (with the exception of any param that was originally in the URL):
    * By default, the route for this new POST request is gonna have the same URL as the original GET action, but appending `/actions/<action_name>` to it. This can be customized by passing the path with the `at:` parameter of the DSL. I.e., `enable_large_params_proxy_action at: /actions/myspecialname` will change the generated path (can use the `//..` syntax to not include the prefix defined for the endpoint). NOTE: this route needs to be compatible with any params that might be defined for the URL (i.e., `:id` and such).
    * This action will be fully visible and fully documented in the API generated docs. However, it will not need to have a corresponding controller implementation.
  * Upon receiving a request to the POST equivalent action, Praxis will detect it is a special action and will:
    * use directly the original action (i.e., will do the before/after filters and call the controller's method)
    * will load the parameters for the action from the incoming payload

This functionality is to allow having a POST counterpart to any GET requests that require long query strings, and for which the client cannot use a payload bodies (i.e,. Browser JS clients cannot send payload on GET requests).