### PR TITLE
Build batch_computed DSL for resources

### DIFF
--- a/spec/praxis/mapper/resource_spec.rb
+++ b/spec/praxis/mapper/resource_spec.rb
@@ -214,4 +214,48 @@ describe Praxis::Mapper::Resource do
       end
     end
   end
+
+  context 'batch computed attributes' do
+    context 'default case' do
+      subject { SimpleResource.new(SimpleModel.new(id: 103, name: 'bigfoot')) }
+      it 'creates the class level method inside the BatchProcessors const in the class' do
+        inner_constant = subject.class.const_get(:BatchProcessors)
+        expect(inner_constant).to be_truthy
+        expect(inner_constant.method(:computed_name)).to be_truthy
+      end
+      it 'connects the class level method to the proc, returning results for all ids' do
+        inner_constant = subject.class.const_get(:BatchProcessors)
+        two = SimpleResource.new(SimpleModel.new(id: 111, name: 'smallshoe'))
+        by_id = {subject.id => subject, two.id => two}
+        expected_batch_result = {
+          103 => 'BATCH_COMPUTED_bigfoot',
+          111 => 'BATCH_COMPUTED_smallshoe',
+        }
+        expect(inner_constant.computed_name(rows_by_id: by_id)).to eq(expected_batch_result)
+      end
+      it 'creates the optional instance method with the same name (by default)' do
+        expect(subject.method(:computed_name)).to be_truthy
+      end
+      it 'connects the instance method to call the proc, returning only its id result' do
+        expect(subject.computed_name).to eq('BATCH_COMPUTED_bigfoot')
+      end
+    end
+
+    context 'disabling instance method creation' do
+      subject { ParentResource.new(SimpleModel.new(id: 3, name: 'papa')) }
+      it 'still creates the class level method inside the BatchProcessors const in the class' do
+        inner_constant = subject.class.const_get(:BatchProcessors)
+        expect(inner_constant).to be_truthy
+        expect(inner_constant.method(:computed_display)).to be_truthy
+      end
+      it 'doe NOT create the optional instance' do
+        expect(subject.methods).to_not include(:computed_display)
+      end
+    end
+
+    it 'can retrieve which attribute names are batched' do
+      expect(SimpleResource.batched_attributes).to eq([:computed_name])
+      expect(ParentResource.batched_attributes).to eq([:computed_display])
+    end
+  end
 end

--- a/spec/praxis/mapper/resource_spec.rb
+++ b/spec/praxis/mapper/resource_spec.rb
@@ -226,10 +226,10 @@ describe Praxis::Mapper::Resource do
       it 'connects the class level method to the proc, returning results for all ids' do
         inner_constant = subject.class.const_get(:BatchProcessors)
         two = SimpleResource.new(SimpleModel.new(id: 111, name: 'smallshoe'))
-        by_id = {subject.id => subject, two.id => two}
+        by_id = { subject.id => subject, two.id => two }
         expected_batch_result = {
           103 => 'BATCH_COMPUTED_bigfoot',
-          111 => 'BATCH_COMPUTED_smallshoe',
+          111 => 'BATCH_COMPUTED_smallshoe'
         }
         expect(inner_constant.computed_name(rows_by_id: by_id)).to eq(expected_batch_result)
       end

--- a/spec/support/spec_resources.rb
+++ b/spec/support/spec_resources.rb
@@ -107,7 +107,7 @@ class ParentResource < BaseResource
   def display_name
     "#{id}-#{name}"
   end
-  batch_computed(:computed_display, with_instance_method: false) do |foo, bar = nil, rows_by_id:|
+  batch_computed(:computed_display, with_instance_method: false) do |rows_by_id:|
     rows_by_id.transform_values do |v|
       "BATCH_COMPUTED_#{v.display_name}"
     end

--- a/spec/support/spec_resources.rb
+++ b/spec/support/spec_resources.rb
@@ -103,6 +103,15 @@ class ParentResource < BaseResource
   model ParentModel
 
   property :display_name, dependencies: %i[simple_name id other_attribute]
+
+  def display_name
+    "#{id}-#{name}"
+  end
+  batch_computed(:computed_display, with_instance_method: false) do |foo, bar = nil, rows_by_id:|
+    rows_by_id.transform_values do |v|
+      "BATCH_COMPUTED_#{v.display_name}"
+    end
+  end
 end
 
 class SimpleResource < BaseResource
@@ -114,6 +123,12 @@ class SimpleResource < BaseResource
 
   def other_resource
     other_model
+  end
+
+  batch_computed(:computed_name) do |rows_by_id:|
+    rows_by_id.transform_values do |v|
+      "BATCH_COMPUTED_#{v.name}"
+    end
   end
 
   property :aliased_method, dependencies: %i[column1 other_model]


### PR DESCRIPTION
Optional DSL to enable easier calculation of expensive attributes that can be calculated much more efficiently in group:
* defining an attribute this way, resources can be used to be much more efficiently to calculate values that can be retrieved much more efficiently in bulk, and/or that depend on other resources of the same type to do so.
* The provided block to calculate the value of the attribute for a collection of resources of the same type is stored as a method inside an inner module of the resource class called BatchProcessors
* The class level method is callable through <ResourceClass>::BatchProcessors.<property_name>(rows_by_id: xxx). The rows_by_id: parameter has resource 'ids' as keys, and the resource instances themselves a values
* By default an instance method of the same <property_name> name will be created, with a default implementation that will call the BatchProcessor.<property_name> with only its instance id and instance, and will return only its result from it.
* If creating the helper instance method is not desired, one can pass "with_instance_method: false" when defining the batched_computed block. This might be necessary if the resource itself has an 'id' property that is not called 'id'. If that's the case, disable the creation, and add your own instance method that uses the defined BatchProcessor method passing the right parameters.
* It is also possible to query which attributes for a resource class are batch computed. This is done through <ResourceClass>.batched_attributes (which returns and array of symbol names)
* Defining batch_computed attributes needs to be done before finalization