### PR TITLE
Handle gets with content types and no bodies for proxied actions

### DIFF
--- a/lib/praxis/bootloader_stages/routing.rb
+++ b/lib/praxis/bootloader_stages/routing.rb
@@ -14,8 +14,14 @@ module Praxis
 
         def call(request)
           dispatcher = Dispatcher.current(application: @application)
-          # Switch to the sister get action if configured that way
-          action = @action.sister_get_action || @action
+          # Switch to the sister get action if configured that way (and mark the request as forwarded)
+          action = \
+            if @action.sister_get_action
+              request.forwarded_from_action = @action
+              @action.sister_get_action
+            else
+              @action
+            end
           dispatcher.dispatch(@controller, action, request)
         end
       end

--- a/spec/functional_spec.rb
+++ b/spec/functional_spec.rb
@@ -111,8 +111,30 @@ describe 'Functional specs' do
         end
       end
     end
+    context 'with a valid request but misusing request content-type' do
+      it 'is still successful and does not get confused about the sister post action' do
+        the_body = StringIO.new('') # This is a GET request passing a body
+        get '/api/clouds/1/instances?api_version=1.0', nil, 'rack.input' => the_body, 'CONTENT_TYPE' => 'application/json', 'global_session' => session
+        expect(last_response.status).to eq(200)
+        expect(last_response.headers['Content-Type']).to(
+          eq('application/vnd.acme.instance;type=collection')
+        )
+      end
+    end
   end
 
+  context 'index using POST sister action' do
+    context 'with a valid request' do
+      it 'is successful and round trips the content type we pass in the body' do
+        payload = { response_content_type: 'application/vnd.acme.instance; type=collection; other=thing' }
+        post '/api/clouds/1/instances/actions/index_using_post?api_version=1.0', JSON.dump(payload), 'CONTENT_TYPE' => 'application/json', 'global_session' => session
+        expect(last_response.status).to eq(200)
+        expect(last_response.headers['Content-Type']).to(
+          eq(payload[:response_content_type])
+        )
+      end
+    end
+  end
   it 'works' do
     the_body = StringIO.new('{}') # This is a funny, GET request expecting a body
     get '/api/clouds/1/instances/2?junk=foo&api_version=1.0', nil, 'rack.input' => the_body, 'CONTENT_TYPE' => 'application/json', 'global_session' => session

--- a/spec/spec_app/design/resources/instances.rb
+++ b/spec/spec_app/design/resources/instances.rb
@@ -24,6 +24,8 @@ module ApiResources
     end
 
     action :index do
+      enable_large_params_proxy_action at: '/actions/index_using_post'
+
       routing do
         get ''
       end


### PR DESCRIPTION
Revamp the switching of forwarded sister actions, for better handling of payloads

* We are now, explicitly marking a request as forwarding the action to the sister get one (rather than just knowing there was such a definition)
* Based on that, we're only gonna try to merge the params from the payload if such forwarding took place in the actual request
* This makes it clearer, more efficient, but especially disambiguates the fact that a normal GET request that tecnically has a sister post action might 'incorrectly' pass some content type with an empty payload, and we'd try to make sense out of that for param merging purposes (and possibly fail)