### PR TITLE
Do not add a `.references` for root table names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## next
   * Switch the locally generated index.html file to browse the generated OpenAPI docs to use `elements` instead of `reDoc`
   * Spruce up the initial Gemfile for the generated example app
+  * Fix Praxis::Mapper ordering code, to not prefix top level columns with the table name, as this completely confuses ActiveRecord which
+    switches to full-on eager loading all of the associations in the top query. i.e., passing an invalid table/column name in a
+    `references` method will trigger that (seemingly a current bug)
 
 ## 2.0.pre.30
   * A few cleanup and robustness additions:

--- a/lib/praxis/extensions/pagination/active_record_pagination_handler.rb
+++ b/lib/praxis/extensions/pagination/active_record_pagination_handler.rb
@@ -36,7 +36,7 @@ module Praxis
             column_prefix = dotted.empty? ? root_resource.model.table_name : ([''] + dotted).join(AttributeFiltering::ActiveRecordFilterQueryBuilder::REFERENCES_STRING_SEPARATOR)
 
             # If the sorting refers to a deeper association, make sure to add the join and the special reference
-            if column_prefix
+            if column_prefix && column_prefix != root_resource.model.table_name
               refval = AttributeFiltering::ActiveRecordFilterQueryBuilder.build_reference_value(column_prefix, query: query)
               # Outter join hash needs to be a string based hash format!! (if it's in symbols, it won't match it and we'll cause extra joins)
               query = query.left_outer_joins(info[:includes]).references(refval)


### PR DESCRIPTION
Change ordering code to no use `references` for a top level column name in sorting. If we do so, using quoted table name, AR will decide to eager load it all!

I've opened an issue about it: https://github.com/rails/rails/issues/47588