### PR TITLE
Improve open api generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Spruced up the scaffolding generation, to be more configurable using a `.praxis_scaffold` file at the root, where one can specify things like
   the base module for all generated classes (`base`), the path of the models directory (`models_dir`) and the version to use (`version`). These, except the models directory can also be passed and overriden by command line arguments (and they would be saved into the config file to be usable in future invocations)
+- More efficient validation of Blueprint structures
+- Fix pseudo bug where the field expander capped subfields as soon as it encountered a type without explicit attributes (i.e., Hash). Instead, it allows any of the subfields to percolate through.
 
 ## 2.0.pre.31
 

--- a/lib/praxis/docs/open_api/operation_object.rb
+++ b/lib/praxis/docs/open_api/operation_object.rb
@@ -31,6 +31,15 @@ module Praxis
             # security: [{}]
             # servers: [{}]
           }
+
+          # Handle versioning header/params for the action in a special way, by linking to the existing component
+          # spec that will be generated globally
+          api_info = ApiDefinition.instance.infos[action.endpoint_definition.version]
+          if (version_with = api_info.version_with)
+            all_parameters.push('$ref' => '#/components/parameters/ApiVersionHeader') if version_with.include?(:header)
+            all_parameters.push('$ref' => '#/components/parameters/ApiVersionParam') if version_with.include?(:params)
+          end
+
           h[:description] = action.description if action.description
           h[:tags] = all_tags.uniq unless all_tags.empty?
           h[:parameters] = all_parameters unless all_parameters.empty?

--- a/lib/praxis/docs/open_api/paths_object.rb
+++ b/lib/praxis/docs/open_api/paths_object.rb
@@ -32,7 +32,7 @@ module Praxis
           id = resource.id
           # fill in the paths hash with a key for each path for each action/route
           resource.actions.each do |action_name, action|
-            params_example =  action.params ? action.params.example(nil) : nil
+            params_example = action.params ? action.params.example(nil) : nil
             url = ActionDefinition.url_description(route: action.route, params: action.params, params_example: params_example)
 
             verb = url[:verb].downcase


### PR DESCRIPTION
Several improvements:
  * Add global parameters for versioning (ApiVersionHeader and ApiVersionParam) appropriately if the API is versioned by them. Have actions point to these definitions by $ref
  * Expect the 'server' definition in the APIDefinition to contain url/description and 'variables' sections which might define variables in the server url
