### PR TITLE
Support newer MySQL versions that require ordering fields to be in select clauses when using DISTINCT

### DIFF
--- a/lib/praxis/extensions/pagination/active_record_pagination_handler.rb
+++ b/lib/praxis/extensions/pagination/active_record_pagination_handler.rb
@@ -45,6 +45,8 @@ module Praxis
             quoted_prefix = AttributeFiltering::ActiveRecordFilterQueryBuilder.quote_column_path(query: query, prefix: column_prefix, column_name: info[:attribute])
             order_clause = Arel.sql(ActiveRecord::Base.sanitize_sql_array("#{quoted_prefix} #{direction}"))
             query = query.order(order_clause)
+            # Add a select for any order clause (unless we're already selecting *), as latest MySQL versions require it for DISTINCT queries
+            query = query.select(quoted_prefix) unless query.select_values.empty?
           end
           query
         end


### PR DESCRIPTION
Add a select for any order clause, as latest MySQL versions require it for DISTINCT queries

* Some of the latest MySQL does complain on an invalid query if you use an ORDER BY component that does not have the corresponding SELECT field. (I believe it is enforced, at least, when the query has a DISTINCT modifier)