### PR TITLE
Field expansion with displayable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## next
 - Allow filtering, ordering and pagination to freely use any attributes (potentially deep ones) when no block for the definition is provided. When continuing to define the allowed fields from within the block, those would still be enforced.
+- Added the ability to easily control the hiding/displayability of MediaType attributes in responses.
+  - it introduces a :displayable custom attribute that accepts an array of opaque strings, which can represent some sort of 'privileges' required to have for it to be renderable.
+  - the expander tooling now, will use such `display_attribute?` method to decide if a given attribute needs to be expanded/displayed or not.
+  - The glue to all this requires defining a `display_attribute?` method in the controllers (with takes an array of string opaque privileges), which needs to return true/false to decide if a given attribute is displayable or now. This method will commonly be connected to the `authz` pieces of your app, and would look at the assigned 'privileges' of the currently logged in 'principal', and simply lookup if the required set of privileges received in the method, fall within the currently assigned ones.
+- Cleanup in the OpenAPI generation for schemas, to more properly surface existing custom attributes into x-{name} attributes as well.
 
 ## 2.0.pre.33
 - Better support for ordefing in newer versions of MySQL:

--- a/gemfiles/active_6.gemfile.lock
+++ b/gemfiles/active_6.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     praxis (2.0.pre.33)
       activesupport (>= 3)
-      attributor (>= 7.0)
+      attributor (>= 7.1)
       mime (~> 0)
       mustermann (>= 1.1)
       rack (>= 1)
@@ -29,7 +29,7 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    attributor (7.0)
+    attributor (7.1)
       activesupport (>= 3)
       hashie (~> 3)
       randexp (~> 0)

--- a/gemfiles/active_7.gemfile.lock
+++ b/gemfiles/active_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     praxis (2.0.pre.33)
       activesupport (>= 3)
-      attributor (>= 7.0)
+      attributor (>= 7.1)
       mime (~> 0)
       mustermann (>= 1.1)
       rack (>= 1)
@@ -28,7 +28,7 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    attributor (7.0)
+    attributor (7.1)
       activesupport (>= 3)
       hashie (~> 3)
       randexp (~> 0)

--- a/lib/praxis.rb
+++ b/lib/praxis.rb
@@ -52,7 +52,6 @@ module Praxis
   autoload :BlueprintAttributeGroup, 'praxis/blueprint_attribute_group'
   autoload :FieldExpander, 'praxis/field_expander'
   autoload :Renderer, 'praxis/renderer'
-
   autoload :Notifications, 'praxis/notifications'
   autoload :MiddlewareApp, 'praxis/middleware_app'
 
@@ -67,6 +66,7 @@ module Praxis
     autoload :FuzzyHash, 'praxis/types/fuzzy_hash'
     autoload :MediaTypeCommon, 'praxis/types/media_type_common'
     autoload :MultipartArray, 'praxis/types/multipart_array'
+    autoload :SplattableStringArray, 'praxis/types/splattable_string_array'
   end
 
   autoload :MediaType, 'praxis/media_type'

--- a/lib/praxis/application.rb
+++ b/lib/praxis/application.rb
@@ -5,6 +5,9 @@ require 'mustermann'
 require 'logger'
 
 module Praxis
+  # Setup the option early, since things like MediaTypes and EndpointDefinitions might need it
+  Attributor::Attribute.custom_option :displayable, Types::SplattableStringArray.of(String)
+
   class Application
     include Singleton
 

--- a/lib/praxis/docs/open_api/schema_object.rb
+++ b/lib/praxis/docs/open_api/schema_object.rb
@@ -5,68 +5,74 @@ module Praxis
     module OpenApi
       class SchemaObject
         # https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schema-object
-        attr_reader :type
+        attr_reader :type, :attribute
 
         def initialize(info:)
-          @attribute_options = {}
-
           # info could be an attribute ... or a type
+          # We will always try to work with the attribute if it is there, otherwise, we'll use type underneath
           if info.is_a?(Attributor::Attribute)
             @type = info.type
-            # Save the options that might be attached to the attribute, to add them to the type schema later
-            @attribute_options = info.options
+            @attribute = info
           else
             @type = info
           end
 
-          # Mediatypes have the description method, lower types don't
-          @attribute_options[:description] = @type.description if @type.respond_to?(:description)
           @collection = type.respond_to?(:member_type)
         end
 
         def dump_example
-          ex = type.example
+          ex = (attribute || type).example
           ex.respond_to?(:dump) ? ex.dump : ex
         end
 
         def dump_schema(shallow: false, allow_ref: false)
+          important_options = [:description, :null]
+          # Compile all options from the underlying tye and attribute (if any), translating them
+          # to OpenAPI schema options with the x- prefix for our custom ones
+          base_options = _slice_options(type,important_options)
+          base_options.merge! _slice_options(type, Attributor::Attribute::custom_options, prefix: 'x')
+          if attribute
+            base_options.merge! _slice_options(attribute, important_options, prefix: 'x')
+            base_options.merge! _slice_options(attribute, Attributor::Attribute::custom_options, prefix: 'x')
+          end
+          # Tag on OpenAPI specific requirements that aren't already added in the underlying JSON schema model
+          # Nullable: (it seems we need to ensure there is a null option to the enum, if there is one)
+          if base_options.key?(:null)
+            base_options[:nullable] = !!base_options.delete(:null)
+          end
+
           # We will dump schemas for mediatypes by simply creating a reference to the components' section
           if type < Attributor::Container && !(type < Praxis::Types::MultipartArray)
             if (type < Praxis::Blueprint || type < Attributor::Model) && allow_ref && !type.anonymous?
-              # TODO: Technically OpenAPI/JSON schema support passing a description when pointing to a $ref (to override it)
+              # NOTE: Technically OpenAPI/JSON schema support passing a description when pointing to a $ref (to override it)
               # However, it seems that UI browsers like redoc or elements have bugs where if that's done, they get into a loop and crash
               # so for now, we're gonna avoid overriding the description until that is solved
-              # h = @attribute_options[:description] ? { 'description' => @attribute_options[:description] } : {}
-              h = {}
+              base_options.delete(:description)
               Praxis::Docs::OpenApiGenerator.instance.register_seen_component(type)
-              h.merge!('$ref' => "#/components/schemas/#{type.id}")
+              base_options.merge!('$ref' => "#/components/schemas/#{type.id}")
             elsif @collection
               items = OpenApi::SchemaObject.new(info: type.member_type).dump_schema(allow_ref: allow_ref, shallow: false)
-              h = @attribute_options[:description] ? { 'description' => @attribute_options[:description] } : {}
-              h.merge!(type: 'array', items: items)
+              base_options.merge!(type: 'array', items: items)
             else # Attributor::Struct, etc
-              required_attributes = (type.describe[:requirements] || []).filter { |r| r[:type] == :all }.map { |r| r[:attributes] }.flatten.compact.uniq
+              reqs = (attribute || type).describe[:requirements]
+              required_attributes = ( reqs || []).filter { |r| r[:type] == :all }.map { |r| r[:attributes] }.flatten.compact.uniq
               props = type.attributes.transform_values do |definition|
                 # if type has an attribute in its requirements all, then it should be marked as required here
                 OpenApi::SchemaObject.new(info: definition).dump_schema(allow_ref: true, shallow: shallow)
               end
-              h = { type: :object }
-              h[:properties] = props if props.presence
-              h[:required] = required_attributes unless required_attributes.empty?
+
+              base_options.merge!( type: :object )
+              base_options[:properties] = props if props.presence
+              base_options[:required] = required_attributes unless required_attributes.empty?
             end
           else
             # OpenApi::SchemaObject.new(info:target).dump_schema(allow_ref: allow_ref, shallow: shallow)
             # TODO...we need to make sure we can use refs in the underlying components after the first level...
             # ... maybe we need to loop over the attributes if it's an object/struct?...
-            h = type.as_json_schema(shallow: shallow, example: nil, attribute_options: @attribute_options)
+            base_options.merge!((attribute || type).as_json_schema(shallow: shallow, example: nil))
           end
 
-          # Tag on OpenAPI specific requirements that aren't already added in the underlying JSON schema model
-          # Nullable: (it seems we need to ensure there is a null option to the enum, if there is one)
-          is_nullable = @attribute_options[:null]
-          h[:nullable] = true if is_nullable
-          h
-
+          base_options
           # # TODO: FIXME: return a generic object type if the passed info was weird.
           # return { type: :object } unless info
 
@@ -115,6 +121,15 @@ module Praxis
           else
             raise "Unknown praxis family type: #{praxis_type[:family]}"
           end
+        end
+        def _slice_options(object, names, prefix: nil)
+          subset = object.options.slice(*names)
+          return subset if prefix.nil?
+
+          subset.transform_keys do |key|
+            "#{prefix}-#{key}".to_sym
+          end
+          subset
         end
       end
     end

--- a/lib/praxis/extensions/field_expansion.rb
+++ b/lib/praxis/extensions/field_expansion.rb
@@ -10,17 +10,20 @@ module Praxis
       end
 
       def expanded_fields
-        @expanded_fields ||= request.action.expanded_fields(request, media_type)
+        @expanded_fields ||= 
+        begin
+          expansion_filter = self.respond_to?(:display_attribute?) ? self.method(:display_attribute?) : nil
+          request.action.expanded_fields(request, media_type, expansion_filter)
+        end
       end
 
       module ActionDefinitionExtension
         extend ActiveSupport::Concern
 
-        def expanded_fields(request, media_type)
+        def expanded_fields(request, media_type, expansion_filter)
           uses_fields = params&.attributes&.key?(:fields)
           fields = uses_fields ? request.params.fields.fields : true
-
-          Praxis::FieldExpander.expand(media_type, fields)
+          Praxis::FieldExpander.expand(media_type, fields, expansion_filter)
         end
       end
     end

--- a/lib/praxis/types/splattable_string_array.rb
+++ b/lib/praxis/types/splattable_string_array.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Praxis
+  module Types
+    class SplattableStringArray < Attributor::Collection
+      # Make a type, to allow to load the value, as s single string, if it isn't a numerable
+      # This way we can do displayable: 'foobar' , or displayable: ['one', 'two']
+      def self.decode_string(value, _context)
+        Array(value)
+      end
+    end
+  end
+end

--- a/praxis.gemspec
+++ b/praxis.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'praxis'
 
   spec.add_dependency 'activesupport', '>= 3'
-  spec.add_dependency 'attributor', '>= 7.0'
+  spec.add_dependency 'attributor', '>= 7.1'
   spec.add_dependency 'mime', '~> 0'
   spec.add_dependency 'mustermann', '>=1.1'
   spec.add_dependency 'rack', '>= 1'

--- a/spec/praxis/extensions/field_expansion_spec.rb
+++ b/spec/praxis/extensions/field_expansion_spec.rb
@@ -35,8 +35,8 @@ describe Praxis::Extensions::FieldExpansion do
 
   let(:test_attributes) {}
   let(:test_params) { double('test_params', attributes: test_attributes) }
-
-  subject(:expansion) { test_instance.expanded_fields(request, media_type) }
+  let(:expansion_filter) { nil }
+  subject(:expansion) { test_instance.expanded_fields(request, media_type, expansion_filter) }
 
   context '#expanded_fields' do
     context 'with fields and view params defined' do

--- a/spec/spec_app/app/controllers/base_class.rb
+++ b/spec/spec_app/app/controllers/base_class.rb
@@ -12,4 +12,16 @@ class BaseClass
   # I.e., you can use class inheritance in cases where it makes sense from an OO point of view
   # but for the most part, you can probably share code through modules/concerns too.
   def this_is_shared; end
+
+  # Just a dummy method to use as if it was an Authenticated concern for the current request...
+  def self.current_user_privs
+    ['special#read']
+  end
+
+  def display_attribute?(privs)
+    # Do not expand, unless the current user has all the required privileges
+    return nil unless ((self.class.current_user_privs & privs) == privs)
+
+    true
+  end
 end

--- a/spec/spec_app/app/resources/book.rb
+++ b/spec/spec_app/app/resources/book.rb
@@ -39,5 +39,14 @@ module Resources
     end
 
     property :grouped_moar_tags, as: :tags
+
+    property :special, dependencies: [:simple_name]
+    def special
+      record.simple_name.reverse # just to make it different
+    end
+    property :multi, dependencies: [:simple_name]
+    def multi
+      record.simple_name.upcase # just to make it different
+    end
   end
 end

--- a/spec/spec_app/design/media_types/book.rb
+++ b/spec/spec_app/design/media_types/book.rb
@@ -12,6 +12,8 @@ class Book < Praxis::MediaType
     attribute :category_uuid, String
     attribute :author, Author
     attribute :tags, Praxis::Collection.of(Tag)
+    attribute :special, String, displayable: 'special#read'
+    attribute :multi, String, displayable: ['special#read', 'normal#read']
 
     group :grouped do
       attribute :id

--- a/spec/support/spec_blueprints.rb
+++ b/spec/support/spec_blueprints.rb
@@ -73,3 +73,18 @@ class SimpleHashCollection < Attributor::Model
     attribute :hash_collection, Attributor::Collection.of(Hash)
   end
 end
+
+class RestrictedBlueprint < Praxis::Blueprint
+  attributes(displayable: 'restricted#read') do
+    attribute :id, Integer
+    attribute :secret_data, String
+    attribute :pii_data, String, displayable: 'pii#read'
+  end
+end
+
+class PseudoRestrictedBlueprint < Praxis::Blueprint
+  attributes do
+    attribute :id, Integer
+    attribute :restricted, RestrictedBlueprint
+  end
+end


### PR DESCRIPTION
This builds an easy way to control the hiding/displayability of MT attributes in requests
* It registers a :displayable custom attribute that can be used in any attribute, and accepts an array of opaque strings, which can represent some sort of 'privileges' required to have for it to be renderable.
* It allows to define a `display_attribute?` method in the controller, which takes a list of required 'privileges' coming from the attribute, and would return true/false to decide if that's a displayable (expandable) attribute (i.e., true if the 'current principal', whatever that means, has all of those privileges assigned).
* The expander tooling now, will use the `display_attribute?` method to decide if that needs to be expanded/displayed or not


This PR also changes the OpenAPI generation for schemas, to more properly surface existing custom attributes into `x-{name}` attributes as well.