### PR TITLE
Abide by the default null behavior when reporting nullable to OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Praxis Changelog
 
 ## next
+- Fix reported nullability property in OpenAPI generation. Looking at null: true | false isn't enough. The system needs to look at the default null behavior from Attributor, to properly ascertain if the exclusion of a 'null' option means nullable or not. This PR fixes this.
 
 ## 2.0.pre.34
 - Allow filtering, ordering and pagination to freely use any attributes (potentially deep ones) when no block for the definition is provided. When continuing to define the allowed fields from within the block, those would still be enforced.

--- a/lib/praxis/blueprint.rb
+++ b/lib/praxis/blueprint.rb
@@ -374,6 +374,8 @@ module Praxis
 
     # Delegates the json-schema methods to the underlying attribute/member_type
     def self.as_json_schema(**args)
+      # TODO: Aren't we loosing the attribute options if we just call the type?? (e.g. description, etc)
+      # Also, we might want to add a 'title' for MTs, to be the class name (without prefixing) ...
       @attribute.type.as_json_schema(args)
     end
 

--- a/lib/praxis/docs/open_api/schema_object.rb
+++ b/lib/praxis/docs/open_api/schema_object.rb
@@ -37,7 +37,10 @@ module Praxis
           end
           # Tag on OpenAPI specific requirements that aren't already added in the underlying JSON schema model
           # Nullable: (it seems we need to ensure there is a null option to the enum, if there is one)
-          base_options[:nullable] = !base_options.delete(:null).nil? if base_options.key?(:null)
+          if base_options.key?(:null)
+            base_options[:nullable] = Attributor::Attribute::nullable_attribute?(base_options)
+            base_options.delete(:null)
+          end
 
           # We will dump schemas for mediatypes by simply creating a reference to the components' section
           if type < Attributor::Container && !(type < Praxis::Types::MultipartArray)


### PR DESCRIPTION
Looking at null: true | false to report nullability in OpenAPI isn't enough.
The system needs to look at the default null behavior from Attributor, to properly ascertain if the exclusion of a 'null' option means nullable or not. This PR fixes this.