### PR TITLE
expose nullable: true when default_for_null is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Praxis Changelog
 
 ## next
+ - OpenAPI generation enhancement:
+   - expose nullable: true, in situations where the 'null:' key isn't specified in an attribute, but the builtin default behavior is true
 
 ## 2.0.pre.35
 - Fix reported nullability property in OpenAPI generation. Looking at null: true | false isn't enough. The system needs to look at the default null behavior from Attributor, to properly ascertain if the exclusion of a 'null' option means nullable or not. This PR fixes this.

--- a/gemfiles/active_6.gemfile.lock
+++ b/gemfiles/active_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    praxis (2.0.pre.34)
+    praxis (2.0.pre.35)
       activesupport (>= 3)
       attributor (>= 7.1)
       mime (~> 0)

--- a/gemfiles/active_7.gemfile.lock
+++ b/gemfiles/active_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    praxis (2.0.pre.34)
+    praxis (2.0.pre.35)
       activesupport (>= 3)
       attributor (>= 7.1)
       mime (~> 0)

--- a/lib/praxis/docs/open_api/schema_object.rb
+++ b/lib/praxis/docs/open_api/schema_object.rb
@@ -40,6 +40,11 @@ module Praxis
           if base_options.key?(:null)
             base_options[:nullable] = Attributor::Attribute::nullable_attribute?(base_options)
             base_options.delete(:null)
+          else
+            # Even though no :null option is passed in, still see if the default is 'nullable', and if so, pass it in.
+            # This is to handle the case where a type is defined as nullable by default, but the user didn't explicitly
+            # pass in the null: true option
+            base_options[:nullable] = true if Attributor::Attribute.default_for_null            
           end
 
           # We will dump schemas for mediatypes by simply creating a reference to the components' section


### PR DESCRIPTION
check default_for_null to expose it as nullable if that's the default behavior, regardless of no null: key passed in in an attribute