### PR TITLE
Prevent IRB from running console in a new Thread

### DIFF
--- a/gemfiles/.gitignore
+++ b/gemfiles/.gitignore
@@ -1,0 +1,3 @@
+/.bundle
+/vendor
+w

--- a/gemfiles/active_7.gemfile
+++ b/gemfiles/active_7.gemfile
@@ -4,7 +4,10 @@
 
 source 'https://rubygems.org'
 
-gem 'activerecord', '>=7'
+# TODO: figure out incompatibility between ActiveRecord 7.1 and SQLite
+# @see https://github.com/praxis/praxis/pull/405#issuecomment-1780570599
+# Until then, we're pinned to 7.0.x for purposes of testing.
+gem 'activerecord', '~> 7.0.8'
 gem 'rubocop'
 gem 'sequel', '~> 5'
 

--- a/lib/praxis/tasks/console.rb
+++ b/lib/praxis/tasks/console.rb
@@ -11,7 +11,7 @@ namespace :praxis do
     Rake::Task['praxis:environment'].invoke
 
     basedir = ::Praxis::Application.instance.root
-    nickname = File.basename(::Praxis::Application.instance.root)
+    nickname = File.basename(basedir)
 
     # Keep IRB.setup from complaining about bad ARGV options
     old_argv = ARGV.dup
@@ -20,7 +20,6 @@ namespace :praxis do
     ARGV.concat(old_argv)
 
     # Remove main object from prompt (its stringify is not useful)
-    nickname = File.basename(::Praxis::Application.instance.root)
     IRB.conf[:PROMPT][:DEFAULT] = {
       PROMPT_I: "%N(#{nickname}):%03n:%i> ",
       PROMPT_N: "%N(#{nickname}):%03n:%i> ",


### PR DESCRIPTION
When we switched `praxis:console` back to using Irb, we adopted `multi-irb` because it was the easiest way to set the `main` binding to the Praxis app instance.

Unfortunately, `multi-irb` spawns a new thread for every instance of the interpreter. If the surrounding Praxis app needs to manipulate thread-local storage before entering the console, that capability is ruined and `multi-irb` provides no "hook" to allow us to execute code surrounding its invocation of the REPL.

Switching back to vanilla `irb` fixes the problem and makes our Irb integration slightly more robust against future major versions of the Ruby stdlib.