### PR TITLE
fix passing of kw args along to as_json_schema

### DIFF
--- a/lib/praxis/types/media_type_common.rb
+++ b/lib/praxis/types/media_type_common.rb
@@ -9,7 +9,7 @@ module Praxis
       module ClassMethods
         def as_json_schema(**args)
           the_type = @attribute&.type || member_type
-          the_type.as_json_schema(args)
+          the_type.as_json_schema(**args)
         end
 
         def json_schema_type


### PR DESCRIPTION
was running into a weird error on attributor with a PR I'm going to put up soon, but basically if a collection of media types was nested within an Attributor::Hash, schema compilation would blow up with an argument length error for that hash object and not show up