### PR TITLE
skip polymorphic relations as they are blowing queries up completely

### DIFF
--- a/lib/praxis/mapper/active_model_compat.rb
+++ b/lib/praxis/mapper/active_model_compat.rb
@@ -37,6 +37,8 @@ module Praxis
           @_praxis_associations = orig.each_with_object({}) do |(k, v), hash|
             # Assume an 'id' primary key if the system is initializing without AR connected
             # (or without the tables created). This probably means that it's a rake task initializing or so...
+            next if v.polymorphic?
+
             pkey = \
               if v.klass.connected? && v.klass.table_exists?
                 v.klass.primary_key


### PR DESCRIPTION
patch for #415 . IIRC, having a polymorphic relation defined in the model at all, was causing the entire field selection to fail. seems like it would be hard to support querying by polymorphic types anyways, so just skipping over it for now which fixes the issue at least 