### PR TITLE
Relax dependency on terminal-table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Praxis Changelog
 
+# Unreleased
+
+- Relax the version specification for the terminal-table dependency
+
 # 2.0.0
 
 - The much expected official 2.0 release of Praxis, that has been pre-releasing in the 'preX' versions for a long time.

--- a/praxis.gemspec
+++ b/praxis.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mime', '~> 0'
   spec.add_dependency 'mustermann', '>=1.1'
   spec.add_dependency 'rack', '>= 1'
-  spec.add_dependency 'terminal-table', '~> 1.4'
+  spec.add_dependency 'terminal-table'
   spec.add_dependency 'thor'
 
   spec.add_development_dependency 'appraisal'


### PR DESCRIPTION
This gem appears to only be used for generating ASCII art for routes via a rake task, and the API is pretty stable. Relaxing the version specification for this gem allows consumers of praxis to manage this transitive dependency more flexibly on their own.